### PR TITLE
Fix precedence between config and cli for {bin,lib}-features

### DIFF
--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -30,10 +30,10 @@ impl BinPackage {
         project: &ProjectDefinition,
         config: &ProjectConfig,
     ) -> Result<Self> {
-        let features = if !config.bin_features.is_empty() {
-            config.bin_features.clone()
-        } else if !cli.bin_features.is_empty() {
+        let features = if !cli.bin_features.is_empty() {
             cli.bin_features.clone()
+        } else if !config.bin_features.is_empty() {
+            config.bin_features.clone()
         } else {
             vec![]
         };

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -44,10 +44,10 @@ impl LibPackage {
             .find(|p| p.name == *name)
             .ok_or_else(|| anyhow!(r#"Could not find the project lib-package "{name}""#,))?;
 
-        let features = if !config.lib_features.is_empty() {
-            config.lib_features.clone()
-        } else if !cli.lib_features.is_empty() {
+        let features = if !cli.lib_features.is_empty() {
             cli.lib_features.clone()
+        } else if !config.lib_features.is_empty() {
+            config.lib_features.clone()
         } else {
             vec![]
         };


### PR DESCRIPTION
Hi,

for `lib-features` and `bin-features`, README says the config  `Can be over-ridden with the command line parameter`.

But running `cargo leptos build --lib-features hydrate,banana --bin-features ssr,apple` on the `start` project compiles fine, while I would expect it to fail because banana and apple are not registered features.

Here is a quick fix, which successfully fail for non-existent features:
```
╰─>$ cargo leptos build --lib-features hydrate,banana --bin-features ssr,apple
error: none of the selected packages contains these features: banana
error: none of the selected packages contains these features: apple
```