### PR TITLE
Fix crash when reloading on macos due to code signing issue (#49)

### DIFF
--- a/src/service/serve.rs
+++ b/src/service/serve.rs
@@ -77,6 +77,15 @@ impl ServerProcess {
                 GRAY.paint(bin.as_str()),
                 GRAY.paint(new_bin_path.as_str())
             );
+
+            // deleting the old copied binary before overwriting to avoid signing issues on macos
+            if fs::remove_file(&new_bin_path).await.is_ok() {
+                log::debug!(
+                    "Deleted server binary {}",
+                    GRAY.paint(new_bin_path.as_str())
+                );
+            }
+
             fs::copy(bin, &new_bin_path).await?;
             // also copy the .pdb file if it exists to allow debugging to attach
             match determine_pdb_filename(bin) {


### PR DESCRIPTION
Fixes #49 

I certainly is a code signing issue.
I do not completely understand why initially copying the file is ok, but overwriting is not.

I found that on the initial start of `watch` (so after the <bin>_leptos file is copied the first time) if I execute the following command every time before doing any file changes, it would fix the issue:
```
codesign --remove-signature target/server/debug/example_leptos
```
Simply deleting the file before copying also does the trick and I would say is good enough.