### PR TITLE
Add `--features` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ for single-package setups, section `[package.metadata.leptos]`.
 # Optional, only necessary if the bin-package defines more than one target
 bin-target = "my-bin-name"
 
+# The features to use when compiling all targets
+#
+# Optional. Can be extended with the command line parameter --features
+features = []
+
 # The features to use when compiling the bin target
 #
 # Optional. Can be over-ridden with the command line parameter --bin-features

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -12,6 +12,7 @@ fn release_opts() -> Opts {
         release: true,
         project: None,
         verbose: 0,
+        features: Vec::new(),
         bin_features: Vec::new(),
         lib_features: Vec::new(),
     }
@@ -21,6 +22,7 @@ fn dev_opts() -> Opts {
         release: false,
         project: None,
         verbose: 0,
+        features: Vec::new(),
         bin_features: Vec::new(),
         lib_features: Vec::new(),
     }

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -30,13 +30,16 @@ impl BinPackage {
         project: &ProjectDefinition,
         config: &ProjectConfig,
     ) -> Result<Self> {
-        let features = if !cli.bin_features.is_empty() {
+        let mut features = if !cli.bin_features.is_empty() {
             cli.bin_features.clone()
         } else if !config.bin_features.is_empty() {
             config.bin_features.clone()
         } else {
             vec![]
         };
+
+        features.extend(config.features.clone());
+        features.extend(cli.features.clone());
 
         let name = project.bin_package.clone();
         let packages = metadata.workspace_packages();

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -20,6 +20,10 @@ pub struct Opts {
     #[arg(short, long)]
     pub project: Option<String>,
 
+    /// The features to use when compiling all targets
+    #[arg(long)]
+    pub features: Vec<String>,
+
     /// The features to use when compiling the lib target
     #[arg(long)]
     pub lib_features: Vec<String>,

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -44,13 +44,16 @@ impl LibPackage {
             .find(|p| p.name == *name)
             .ok_or_else(|| anyhow!(r#"Could not find the project lib-package "{name}""#,))?;
 
-        let features = if !cli.lib_features.is_empty() {
+        let mut features = if !cli.lib_features.is_empty() {
             cli.lib_features.clone()
         } else if !config.lib_features.is_empty() {
             config.lib_features.clone()
         } else {
             vec![]
         };
+
+        features.extend(config.features.clone());
+        features.extend(cli.features.clone());
 
         let abs_dir = package.manifest_path.clone().without_last();
         let rel_dir = abs_dir.unbase(&metadata.workspace_root)?;

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -137,6 +137,8 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub bin_target: String,
     #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
     pub lib_features: Vec<String>,
     #[serde(default)]
     pub lib_default_features: bool,

--- a/src/config/snapshots/cargo_leptos__config__tests__project.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__project.snap
@@ -75,6 +75,7 @@ Config {
     cli: Opts {
         release: false,
         project: None,
+        features: [],
         lib_features: [],
         bin_features: [],
         verbose: 0,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -128,6 +128,7 @@ Config {
     cli: Opts {
         release: false,
         project: None,
+        features: [],
         lib_features: [],
         bin_features: [],
         verbose: 0,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -70,6 +70,7 @@ Config {
     cli: Opts {
         release: false,
         project: None,
+        features: [],
         lib_features: [],
         bin_features: [],
         verbose: 0,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -68,6 +68,7 @@ Config {
         project: Some(
             "project1",
         ),
+        features: [],
         lib_features: [],
         bin_features: [],
         verbose: 0,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -72,6 +72,7 @@ Config {
         project: Some(
             "project2",
         ),
+        features: [],
         lib_features: [],
         bin_features: [],
         verbose: 0,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5,6 +5,7 @@ fn opts(project: Option<&str>) -> crate::config::Opts {
         release: false,
         project: project.map(|s| s.to_string()),
         verbose: 0,
+        features: Vec::new(),
         bin_features: Vec::new(),
         lib_features: Vec::new(),
     }


### PR DESCRIPTION
Hi,

This PR add a `--feature` flag to enable features on all build, and shortcut
`cargo leptos watch --lib-features hydrate,banana --bin-features ssr,banana` into 
`cargo leptos watch --features banana`.