### PR TITLE
Fix server testing.

### DIFF
--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -61,9 +61,11 @@ pub fn build_cargo_server_cmd(
     let mut args = vec![
         cmd.to_string(),
         format!("--package={}", proj.bin.name.as_str()),
-        format!("--bin={}", proj.bin.target),
-        "--target-dir=target/server".to_string(),
     ];
+    if cmd != "test" {
+        args.push(format!("--bin={}", proj.bin.target))
+    }
+    args.push("--target-dir=target/server".to_string());
     if let Some(triple) = &proj.bin.target_triple {
         args.push(format!("--target={triple}"));
     }


### PR DESCRIPTION
Changes arguments passed to `cargo test` so that all server test targets are executed.

Resolves https://github.com/leptos-rs/cargo-leptos/issues/66

@akesson This PR depends on an upstream fix in the leptos crate. This is required to resolve an issue with doctests and server functions. Suggest this PR is not released until leptos 0.1.4 is available.