### PR TITLE
Add feature to prevent downloading dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,4 @@ temp-dir = "0.1"
 
 [features]
 full_tests = []
+no_downloads = []

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Build tool for [Leptos](https://crates.io/crates/leptos):
 - `build` build the server and client.
 - `end2end` command for building, running the server and calling a bash shell hook. The hook would typically launch Playwright or similar.
 - `new` command for creating a new project based on templates, using [cargo-generate](https://cargo-generate.github.io/cargo-generate/index.html). WIP: You'll need to ask on the Leptos [discord](https://discord.gg/YdRAhS7eQB) for the url of a template.
-
+- 'no_downloads' feature to allow user management of optional dependencies
   <br/>
 
 # Getting started
@@ -47,6 +47,12 @@ Install:
 If you for any reason needs the bleeding-edge super fresh version:
 
 > `cargo install --git https://github.com/akesson/cargo-leptos cargo-leptos`
+
+If you wish to handle your own dependencies, or are using Nix or NixOs, you can
+install it with the `no_downloads` feature enabled to prevent cargo-leptos from
+trying to download and install optional deps like dart-sass.
+
+> `cargo install --features no_downloads --locked cargo-leptos`
 
 Help:
 

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -98,8 +98,7 @@ impl ExeMeta {
             Ok(path)
         } else {
             if cfg!(feature="no_downloads"){
-                bail!("{} is required but was not found. Please install
-                       it using your OS's tool of choice", &self.name);
+                bail!("{} is required but was not found. Please install it using your OS's tool of choice", &self.name);
             }
             self.download().await
         }

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -97,6 +97,10 @@ impl ExeMeta {
         if let Ok(path) = self.exe_in_cache() {
             Ok(path)
         } else {
+            if cfg!(feature="no_downloads"){
+                bail!("{} is required but was not found. Please install
+                       it using your OS's tool of choice", &self.name);
+            }
             self.download().await
         }
     }


### PR DESCRIPTION
To better support Nix, it's good to not download anything during initialization or setup, and let Nix handle any additional deps. This PR throws an error if cargo leptos is built with the no_downloads feature and it needs something.