### PR TITLE
Fix cancelling of builds.

### DIFF
--- a/src/command/end2end.rs
+++ b/src/command/end2end.rs
@@ -18,6 +18,9 @@ pub async fn end2end_all(conf: &Config) -> Result<()> {
 pub async fn end2end_proj(proj: &Arc<Project>) -> Result<()> {
     if let Some(e2e) = &proj.end2end {
         super::build::build_proj(proj).await.dot()?;
+        if Interrupt::is_shutdown_requested().await {
+            return Ok(());
+        }
         let server = serve::spawn(proj).await;
         try_run(&e2e.cmd, &e2e.dir)
             .await

--- a/src/command/serve.rs
+++ b/src/command/serve.rs
@@ -3,9 +3,14 @@ use std::sync::Arc;
 use crate::config::Project;
 use crate::ext::anyhow::{Context, Result};
 use crate::service::serve;
+use crate::signal::Interrupt;
 
 pub async fn serve(proj: &Arc<Project>) -> Result<()> {
     super::build::build_proj(proj).await.dot()?;
+    if Interrupt::is_shutdown_requested().await {
+        return Ok(());
+    }
+
     let server = serve::spawn(proj).await;
     server.await??;
     Ok(())

--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -14,6 +14,9 @@ use super::build::build_proj;
 
 pub async fn watch(proj: &Arc<Project>) -> Result<()> {
     build_proj(proj).await?;
+    if Interrupt::is_shutdown_requested().await {
+        return Ok(());
+    }
 
     let _watch = service::notify::spawn(proj).await?;
 


### PR DESCRIPTION
This commit is proposed as a solution to https://github.com/leptos-rs/cargo-leptos/issues/54

The `build_proj` function did not consider the Outcome of each compile stage. This function has been altered so the build is short circuited if a compile is stopped.

Likewise the `build_all` function would build a list of projects without checking for shutdowns. This function has been changed to check after a call to `build_proj` to also short circuit if a shutdown is requested.

build_proj is called from end2end and at the start of a watch.  Both these modules have been changed so that after `build_proj` has been called they check for shutdown requests and exit if required.