### PR TITLE
Make cache dir optional for users building with no_downloads feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ playwright/.cache/
 **/.env
 
 .DS_Store
+
+.direnv
+.envrc
+flake.nix
+flake.lock

--- a/src/ext/tests.rs
+++ b/src/ext/tests.rs
@@ -6,7 +6,9 @@ use temp_dir::TempDir;
 #[tokio::test]
 async fn download_sass() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::Sass.meta_with_dir(dir.path().to_path_buf()).unwrap();
+    let meta = Exe::Sass
+        .meta_with_dir(Some(dir.path().to_path_buf()))
+        .unwrap();
     let e = meta.from_cache().await;
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
@@ -18,7 +20,7 @@ async fn download_sass() {
 async fn download_cargo_generate() {
     let dir = TempDir::new().unwrap();
     let meta = Exe::CargoGenerate
-        .meta_with_dir(dir.path().to_path_buf())
+        .meta_with_dir(Some(dir.path().to_path_buf()))
         .unwrap();
 
     let e = meta.from_cache().await;
@@ -32,7 +34,7 @@ async fn download_cargo_generate() {
 async fn download_wasmopt() {
     let dir = TempDir::new().unwrap();
     let meta = Exe::WasmOpt
-        .meta_with_dir(dir.path().to_path_buf())
+        .meta_with_dir(Some(dir.path().to_path_buf()))
         .unwrap();
     let e = meta.from_cache().await;
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));


### PR DESCRIPTION
I've made some changes to the Exe file to make cache_folder optional, which solves some other problems for NIx users. Everything still seems to work as expected, and all the tests pass.

Love to get another release for cargo-leptos Nix users if everything checks out