### PR TITLE
Show a better error if cargo-generate does not exist

### DIFF
--- a/src/command/new.rs
+++ b/src/command/new.rs
@@ -58,7 +58,7 @@ impl NewCommand {
             .arg("generate")
             .args(&args)
             .spawn()
-            .context("Could not spawn command")?;
+            .context("Could not spawn cargo-generate command (verify that it is installed)")?;
         process.wait().await.dot()?;
         Ok(())
     }


### PR DESCRIPTION
Ran into this just now:
```
shell ❯ cargo leptos new --git https://github.com/Gentle/start-axum-workspace
Error: Could not spawn command at `/home/k/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.1.8/src/command/new.rs:61:14`

Caused by:
    No such file or directory (os error 2)
```