### PR TITLE
Run style rebuilds separately

### DIFF
--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -65,9 +65,10 @@ pub async fn run_loop(proj: &Arc<Project>) -> Result<()> {
             let proj = Arc::clone(&proj);
             async move {
                 let style = compile::style(&proj, &changes).await;
-                if let Ok(Outcome::Success(Product::Style(_))) = style {
+                if let Ok(Ok(Outcome::Success(Product::Style(_)))) = style.await {
                     ReloadSignal::send_style();
-                    log::info!("Watch updated style")
+                    log::info!("Watch updated style");
+                    Interrupt::clear_source_changes().await;
                 }
             }
         });

--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -67,6 +67,7 @@ pub async fn run_loop(proj: &Arc<Project>) -> Result<()> {
                 let style = compile::style(&proj, &changes).await;
                 if let Ok(Outcome::Success(Product::Style(_))) = style {
                     ReloadSignal::send_style();
+                    log::info!("Watch updated style")
                 }
             }
         });

--- a/src/ext/cargo.rs
+++ b/src/ext/cargo.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashSet};
+use std::collections::HashSet;
 
-use camino::{Utf8PathBuf, Utf8Path};
-use cargo_metadata::{Metadata, Package, PackageId, Resolve, Target, MetadataCommand};
 use super::anyhow::Result;
-use super::{PathExt, PathBufExt};
+use super::{PathBufExt, PathExt};
+use camino::{Utf8Path, Utf8PathBuf};
+use cargo_metadata::{Metadata, MetadataCommand, Package, PackageId, Resolve, Target};
 
 pub trait PackageExt {
     fn has_bin_target(&self) -> bool;
@@ -55,7 +55,6 @@ pub trait MetadataExt {
 }
 
 impl MetadataExt for Metadata {
-
     fn load_cleaned(manifest_path: &Utf8Path) -> Result<Metadata> {
         let mut metadata = MetadataCommand::new().manifest_path(manifest_path).exec()?;
         metadata.workspace_root.clean_windows_path();
@@ -70,7 +69,10 @@ impl MetadataExt for Metadata {
     }
 
     fn rel_target_dir(&self) -> Utf8PathBuf {
-        self.target_directory.clone().unbase(&self.workspace_root).unwrap()
+        self.target_directory
+            .clone()
+            .unbase(&self.workspace_root)
+            .unwrap()
     }
 
     fn package_for(&self, id: &PackageId) -> Option<&Package> {
@@ -78,7 +80,7 @@ impl MetadataExt for Metadata {
     }
 
     fn path_dependencies(&self, id: &PackageId) -> Vec<Utf8PathBuf> {
-        let Some(resolve) = &self.resolve else {   
+        let Some(resolve) = &self.resolve else {
              return vec![]
         };
         let mut found = vec![];
@@ -97,8 +99,14 @@ impl MetadataExt for Metadata {
 
     fn src_path_dependencies(&self, id: &PackageId) -> Vec<Utf8PathBuf> {
         let root = &self.workspace_root;
-        self.path_dependencies(id).iter().map(|p| p.unbase(root).unwrap_or_else(|_| 
-            p.to_path_buf()).join("src")).collect()
+        self.path_dependencies(id)
+            .iter()
+            .map(|p| {
+                p.unbase(root)
+                    .unwrap_or_else(|_| p.to_path_buf())
+                    .join("src")
+            })
+            .collect()
     }
 }
 
@@ -112,7 +120,7 @@ impl ResolveExt for Resolve {
             if set.insert(node.id.clone()) {
                 for dep in &node.deps {
                     self.deps_for(&dep.pkg, set);
-                }    
+                }
             }
         }
     }


### PR DESCRIPTION
Addresses #108. At present, if any lib/bin files are touched, the build process waits for style, lib, and bin all to be rebuilt before sending a reload signal, even though it *could* send the style reload signal separately, as this is usually a faster process (Tailwind vs. rustc). 

> Note: This isn't as relevant with plain CSS or with SASS, because in those cases only CSS files are touched and not Rust, so lib/bin aren't recompiled. 

I made this small change to spawn the style rebuild separately rather than joining it with the Rust rebuild.

~However, it only works once, i.e., on first file save. I assume this is because the compilation process that's running in this loop isn't interrupted and stopped if I make another file edit, but I'm not sure. I'm pretty weak on Tokio/concurrent stuff so this may not be the right way to do this.~

Edit: latest commit should actually fix the issue in which it would only recompile styles once, by clearing out the source changes.