### PR TITLE
[docs] Change `akesson` to `leptos-rs` in Github URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Install:
 
 If you, for any reason, need the bleeding-edge super fresh version:
 
-> `cargo install --git https://github.com/akesson/cargo-leptos cargo-leptos`
+> `cargo install --git https://github.com/leptos-rs/cargo-leptos --locked cargo-leptos`
 
 Help:
 
 > `cargo leptos --help`
 
-For setting up your project, have a look at the [examples](https://github.com/akesson/cargo-leptos/tree/main/examples)
+For setting up your project, have a look at the [examples](https://github.com/leptos-rs/cargo-leptos/tree/main/examples)
 
 <br/>
 

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -16,7 +16,7 @@ leptos_router = { version = "0.2", default-features = false, features = [
 leptos_dom = { version = "0.2", default-features = false }
 leptos_actix = { version = "0.2" }
 
-# See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
+# See https://github.com/leptos-rs/cargo-leptos for documentation of all the parameters.
 
 # A leptos project defines which workspace members
 # that are used together frontend (lib) & server (bin)

--- a/examples/workspace/project2/Cargo.toml
+++ b/examples/workspace/project2/Cargo.toml
@@ -59,7 +59,7 @@ ssr = [
 
 
 [package.metadata.leptos]
-# See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
+# See https://github.com/leptos-rs/cargo-leptos for documentation of all the parameters.
 
 # [Optional] Files in the asset_dir will be copied to the target/site directory
 assets-dir = "src/assets"


### PR DESCRIPTION
Also add missing `--locked` to custom install command in README.

(see [discord](https://discord.com/channels/1031524867910148188/1040262908074000425/1103770256738107443) for why). 

I think this is a dupe, but more thorough implementation of #119. 