### PR TITLE
Chore: Clippy fixes

### DIFF
--- a/src/compile/style.rs
+++ b/src/compile/style.rs
@@ -31,7 +31,7 @@ pub async fn style(
             log::debug!("Style no build needed {changes:?}");
             return Ok(Outcome::Success(Product::None));
         }
-        Ok(build(&proj).await?)
+        build(&proj).await
     })
 }
 fn build_sass(proj: &Arc<Project>) -> JoinHandle<Result<Outcome<String>>> {
@@ -47,7 +47,7 @@ fn build_sass(proj: &Arc<Project>) -> JoinHandle<Result<Outcome<String>>> {
             .await
             .dot()?;
         match style_file.source.extension() {
-            Some("sass") | Some("scss") => compile_sass(&style_file, proj.release)
+            Some("sass") | Some("scss") => compile_sass(style_file, proj.release)
                 .await
                 .context(format!("compile sass/scss: {}", &style_file)),
             Some("css") => Ok(Outcome::Success(
@@ -66,7 +66,7 @@ fn build_tailwind(proj: &Arc<Project>) -> JoinHandle<Result<Outcome<String>>> {
             return Ok(Outcome::Success("".to_string()));
         };
         log::trace!("Tailwind config: {:?}", &tw_conf);
-        compile_tailwind(&proj, &tw_conf).await
+        compile_tailwind(&proj, tw_conf).await
     })
 }
 
@@ -82,7 +82,7 @@ async fn build(proj: &Arc<Project>) -> Result<Outcome<Product>> {
         (Failed, _) | (_, Failed) => return Ok(Failed),
         (Success(css), Success(tw)) => format!("{css}\n{tw}"),
     };
-    Ok(Outcome::Success(process_css(&proj, css).await?))
+    Ok(Outcome::Success(process_css(proj, css).await?))
 }
 
 fn browser_lists(query: &str) -> Result<Option<Browsers>> {

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -106,7 +106,7 @@ impl BinPackage {
             abs_dir,
             rel_dir,
             exe_file,
-            target: target.name.to_string(),
+            target: target.name,
             features,
             default_features: config.bin_default_features,
             src_paths,

--- a/src/config/end2end.rs
+++ b/src/config/end2end.rs
@@ -19,7 +19,7 @@ impl End2EndConfig {
 
         Some(Self {
             cmd: cmd.clone(),
-            dir: dir.clone(),
+            dir,
         })
     }
 }

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -70,7 +70,7 @@ impl LibPackage {
                 .join("front")
                 .join("wasm32-unknown-unknown")
                 .join(profile.to_string())
-                .join(&name.replace('-', "_"))
+                .join(name.replace('-', "_"))
                 .with_extension("wasm");
             let site = config
                 .site_pkg_dir

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,7 +67,7 @@ impl Config {
         }
 
         Ok(Self {
-            working_dir: metadata.workspace_root.clone(),
+            working_dir: metadata.workspace_root,
             projects,
             cli,
             watch,

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -25,12 +25,10 @@ impl Profile {
             } else {
                 Self::Release
             }
+        } else if let Some(debug) = debug {
+            Self::Named(debug.clone())
         } else {
-            if let Some(debug) = debug {
-                Self::Named(debug.clone())
-            } else {
-                Self::Debug
-            }
+            Self::Debug
         }
     }
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -61,7 +61,7 @@ impl Project {
         metadata: &Metadata,
         watch: bool,
     ) -> Result<Vec<Arc<Project>>> {
-        let projects = ProjectDefinition::parse(&metadata)?;
+        let projects = ProjectDefinition::parse(metadata)?;
 
         let mut resolved = Vec::new();
         for (project, mut config) in projects {
@@ -69,7 +69,7 @@ impl Project {
                 config.output_name = project.name.to_string();
             }
 
-            let lib = LibPackage::resolve(cli, &metadata, &project, &config)?;
+            let lib = LibPackage::resolve(cli, metadata, &project, &config)?;
 
             let js_dir = config
                 .js_dir
@@ -80,7 +80,7 @@ impl Project {
                 working_dir: metadata.workspace_root.clone(),
                 name: project.name.clone(),
                 lib,
-                bin: BinPackage::resolve(cli, &metadata, &project, &config)?,
+                bin: BinPackage::resolve(cli, metadata, &project, &config)?,
                 style: StyleConfig::new(&config)?,
                 watch,
                 release: cli.release,
@@ -95,7 +95,7 @@ impl Project {
 
         let projects_in_cwd = resolved
             .iter()
-            .filter(|p| p.bin.abs_dir.starts_with(&cwd) || p.lib.abs_dir.starts_with(&cwd))
+            .filter(|p| p.bin.abs_dir.starts_with(cwd) || p.lib.abs_dir.starts_with(cwd))
             .collect::<Vec<_>>();
 
         if projects_in_cwd.len() == 1 {
@@ -269,7 +269,7 @@ impl ProjectDefinition {
 }
 
 fn leptos_metadata(metadata: &serde_json::Value) -> Option<&serde_json::Value> {
-    metadata.as_object().map(|o| o.get("leptos")).flatten()
+    metadata.as_object().and_then(|o| o.get("leptos"))
 }
 
 fn default_site_addr() -> SocketAddr {

--- a/src/ext/cargo.rs
+++ b/src/ext/cargo.rs
@@ -15,7 +15,7 @@ pub trait PackageExt {
 
 impl PackageExt for Package {
     fn has_bin_target(&self) -> bool {
-        self.targets.iter().find(|t| t.is_bin()).is_some()
+        self.targets.iter().any(|t| t.is_bin())
     }
 
     fn bin_targets(&self) -> Box<dyn Iterator<Item = &Target> + '_> {
@@ -62,7 +62,7 @@ impl MetadataExt for Metadata {
         for package in &mut metadata.packages {
             package.manifest_path.clean_windows_path();
             for dependency in &mut package.dependencies {
-                dependency.path.as_mut().map(|p| p.clean_windows_path());
+                if let Some(p) = dependency.path.as_mut() { p.clean_windows_path() }
             }
         }
         Ok(metadata)

--- a/src/ext/fs.rs
+++ b/src/ext/fs.rs
@@ -124,7 +124,7 @@ async fn cp_dir_all(src: impl AsRef<Utf8Path>, dst: impl AsRef<Path>) -> Result<
 
         while let Some(Ok(entry)) = entries.next() {
             let from = entry.path().to_owned();
-            let to = from.rebase(&src, &dst)?;
+            let to = from.rebase(src, &dst)?;
 
             if entry.file_type()?.is_dir() {
                 self::create_dir(&to).await?;

--- a/src/ext/path.rs
+++ b/src/ext/path.rs
@@ -78,7 +78,7 @@ impl PathBufExt for Utf8PathBuf {
     }
 
     fn test_string(&self) -> String {
-        let s = self.to_string().replace("\\", "/");
+        let s = self.to_string().replace('\\', "/");
         if s.ends_with(".exe") {
             s[..s.len() - 4].to_string()
         } else {

--- a/src/service/notify.rs
+++ b/src/service/notify.rs
@@ -139,7 +139,7 @@ pub enum Watched {
 fn convert(p: &Path, proj: &Project) -> Result<Utf8PathBuf> {
     let p = Utf8PathBuf::from_path_buf(p.to_path_buf())
         .map_err(|e| anyhow!("Could not convert to a Utf8PathBuf: {e:?}"))?;
-    Ok(p.unbase(&proj.working_dir).unwrap_or_else(|_| p))
+    Ok(p.unbase(&proj.working_dir).unwrap_or(p))
 }
 
 impl Watched {
@@ -188,8 +188,7 @@ impl Watched {
     pub fn path_starts_with_any(&self, paths: &[&Utf8PathBuf]) -> bool {
         paths
             .iter()
-            .find(|path| self.path_starts_with(path))
-            .is_some()
+            .any(|path| self.path_starts_with(path))
     }
 }
 

--- a/src/service/site.rs
+++ b/src/service/site.rs
@@ -97,10 +97,10 @@ impl fmt::Debug for Site {
 
 impl Site {
     pub fn new(config: &ProjectConfig) -> Self {
-        let mut reload = config.site_addr.clone();
+        let mut reload = config.site_addr;
         reload.set_port(config.reload_port);
         Self {
-            addr: config.site_addr.clone(),
+            addr: config.site_addr,
             reload,
             root_dir: config.site_root.clone(),
             pkg_dir: config.site_pkg_dir.clone(),
@@ -174,7 +174,7 @@ impl Site {
         if let Some(hash) = self.file_reg.read().await.get(site.as_str()).copied() {
             Ok(Some(hash))
         } else if dest.exists() {
-            Ok(Some(file_hash(&dest).await?))
+            Ok(Some(file_hash(dest).await?))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
I am think about starting an issue here..
While I read the code, and get my bearings

it is my habit to run

Cargo clippy
Cargo outdated
Cargo machete

This maybe the first of a few PRs..

"I Ran cargo clippy --fix "

and then reviewed all the changes..

It took me a little time to justify this change
but I see no change in functionality.

```
-    metadata.as_object().map(|o| o.get("leptos")).flatten()
+    metadata.as_object().and_then(|o| o.get("leptos"))
```

Also few .clone() call have been removed which is always nice to see.