### PR TITLE
feat: #146: end to end with watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ playwright/.cache/
 **/.env
 
 .DS_Store
+.vscode/*

--- a/examples/project/end2end/playwright.config.ts
+++ b/examples/project/end2end/playwright.config.ts
@@ -51,19 +51,19 @@ const config: PlaywrightTestConfig = {
       },
     },
 
-    {
-      name: "firefox",
-      use: {
-        ...devices["Desktop Firefox"],
-      },
-    },
+    // {
+    //   name: "firefox",
+    //   use: {
+    //     ...devices["Desktop Firefox"],
+    //   },
+    // },
 
-    {
-      name: "webkit",
-      use: {
-        ...devices["Desktop Safari"],
-      },
-    },
+    // {
+    //   name: "webkit",
+    //   use: {
+    //     ...devices["Desktop Safari"],
+    //   },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/examples/project/end2end/tests/example.spec.ts
+++ b/examples/project/end2end/tests/example.spec.ts
@@ -5,5 +5,5 @@ test("homepage has title and links to intro page", async ({ page }) => {
 
   await expect(page).toHaveTitle("Cargo Leptos");
 
-  await expect(page.locator("h1")).toHaveText("Hi from your Leptos WASM!");
+  await expect(page.locator("h2")).toHaveText("Welcome to Leptos");
 });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,12 +1,11 @@
 mod build;
-mod end2end;
+pub mod end2end;
 mod new;
 mod serve;
 mod test;
 pub mod watch;
 
 pub use build::build_all;
-pub use end2end::end2end_all;
 pub use new::NewCommand;
 pub use serve::serve;
 pub use test::test_all;

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -1,6 +1,6 @@
 use crate::compile::{front_cargo_process, server_cargo_process};
 use crate::config::{Config, Project};
-use crate::ext::anyhow::{Context, Result, anyhow};
+use crate::ext::anyhow::{anyhow, Context, Result};
 use crate::logger::GRAY;
 
 pub async fn test_all(conf: &Config) -> Result<()> {

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -58,12 +58,14 @@ pub struct Cli {
 
 impl Cli {
     pub fn opts(&self) -> Option<Opts> {
-        use Commands::{Build, EndToEnd, New, Serve, Test, Watch};
         match &self.command {
-            New(_) => None,
-            Build(opts) | Serve(opts) | Test(opts) | EndToEnd(opts) | Watch(opts) => {
-                Some(opts.clone())
-            }
+            Commands::New(_) => None,
+            Commands::Build(opts)
+            | Commands::Serve(opts)
+            | Commands::Test(opts)
+            | Commands::EndToEnd(opts)
+            | Commands::EndToEndWithWatch(opts)
+            | Commands::Watch(opts) => Some(opts.clone()),
         }
     }
 }
@@ -74,8 +76,10 @@ pub enum Commands {
     Build(Opts),
     /// Run the cargo tests for app, client and server.
     Test(Opts),
-    /// Start the server and end-2-end tests.
+    /// Run end-2-end tests.
     EndToEnd(Opts),
+    /// Start the server and end-2-end tests.
+    EndToEndWithWatch(Opts),
     /// Serve. Defaults to hydrate mode.
     Serve(Opts),
     /// Serve and automatically reload when files change.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,13 +47,13 @@ pub async fn run(args: Cli) -> Result<()> {
     );
 
     let _monitor = Interrupt::run_ctrl_c_monitor();
-    use Commands::{Build, EndToEnd, New, Serve, Test, Watch};
     match args.command {
-        New(_) => panic!(),
-        Build(_) => command::build_all(&config).await,
-        Serve(_) => command::serve(&config.current_project()?).await,
-        Test(_) => command::test_all(&config).await,
-        EndToEnd(_) => command::end2end_all(&config).await,
-        Watch(_) => command::watch(&config.current_project()?).await,
+        Commands::New(_) => panic!(),
+        Commands::Build(_) => command::build_all(&config).await,
+        Commands::Serve(_) => command::serve(&config.current_project()?).await,
+        Commands::Test(_) => command::test_all(&config).await,
+        Commands::EndToEnd(_) => command::end2end::end2end_all(&config).await,
+        Commands::EndToEndWithWatch(_) => command::end2end::end2end_all_with_watch(&config).await,
+        Commands::Watch(_) => command::watch(&config.current_project()?).await,
     }
 }


### PR DESCRIPTION
Seperate the e2e test command into two commands, one which only runs the e2e tests, and one which runs watch and then e2e tests.

Some house keeping:
- set nightly toolchain in workspace
- update test to follow example
- use chromium by default in example

Feel free to come with comments and suggestions.

Closes #146
