### PR TITLE
Cargo wrappers

### DIFF
--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -52,7 +52,7 @@ pub async fn server(
 }
 
 pub fn server_cargo_process(cmd: &str, proj: &Project) -> Result<(String, String, Child)> {
-    let mut command = Command::new("cargo");
+    let mut command = Command::new(proj.bin.cargo_command.as_deref().unwrap_or("cargo"));
     let (envs, line) = build_cargo_server_cmd(cmd, proj, &mut command);
     Ok((envs, line, command.spawn()?))
 }

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -69,7 +69,10 @@ pub fn build_cargo_server_cmd(
     if cmd != "test" {
         args.push(format!("--bin={}", proj.bin.target))
     }
-    args.push("--target-dir=target/server".to_string());
+    args.push(format!(
+        "--target-dir={}",
+        proj.bin.target_dir.as_deref().unwrap_or("target/server")
+    ));
     if let Some(triple) = &proj.bin.target_triple {
         args.push(format!("--target={triple}"));
     }

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -74,6 +74,24 @@ fn test_project_release() {
 }
 
 #[test]
+fn test_bin_target_dir() {
+    std::env::set_var("LEPTOS_BIN_TARGET_DIR", "alternate-target/server");
+    let cli = dev_opts();
+    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true);
+
+    let mut command = Command::new("cargo");
+    let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
+
+    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --target-dir=alternate-target/server --no-default-features --features=ssr");
+
+    let mut command = Command::new("cargo");
+    let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
+
+    assert_display_snapshot!(cargo, @"cargo build --package=example --lib --target-dir=target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate");
+    std::env::remove_var("LEPTOS_BIN_TARGET_DIR");
+}
+
+#[test]
 fn test_workspace_project1() {
     const ENV_REF: &str = if cfg!(windows) {
         "\

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -23,6 +23,7 @@ pub struct BinPackage {
     pub src_paths: Vec<Utf8PathBuf>,
     pub profile: Profile,
     pub target_triple: Option<String>,
+    pub target_dir: Option<String>,
     pub cargo_command: Option<String>,
 }
 
@@ -113,6 +114,7 @@ impl BinPackage {
             src_paths,
             profile,
             target_triple: config.bin_target_triple.clone(),
+            target_dir: config.bin_target_dir.clone(),
             cargo_command: config.bin_cargo_command.clone(),
         })
     }

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -23,6 +23,7 @@ pub struct BinPackage {
     pub src_paths: Vec<Utf8PathBuf>,
     pub profile: Profile,
     pub target_triple: Option<String>,
+    pub cargo_command: Option<String>,
 }
 
 impl BinPackage {
@@ -112,6 +113,7 @@ impl BinPackage {
             src_paths,
             profile,
             target_triple: config.bin_target_triple.clone(),
+            cargo_command: config.bin_cargo_command.clone(),
         })
     }
 }

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -47,6 +47,7 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_END2END_DIR" => conf.end2end_dir = Some(Utf8PathBuf::from(val)),
             "LEPTOS_BROWSERQUERY" => conf.browserquery = val,
             "LEPTOS_BIN_TARGET_TRIPLE" => conf.bin_target_triple = Some(val),
+            "LEPTOS_BIN_CARGO_COMMAND" => conf.bin_cargo_command = Some(val),
             _ if key.starts_with("LEPTOS_") => {
                 log::warn!("Env {key} is not used by cargo-leptos")
             }

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -47,6 +47,7 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_END2END_DIR" => conf.end2end_dir = Some(Utf8PathBuf::from(val)),
             "LEPTOS_BROWSERQUERY" => conf.browserquery = val,
             "LEPTOS_BIN_TARGET_TRIPLE" => conf.bin_target_triple = Some(val),
+            "LEPTOS_BIN_TARGET_DIR" => conf.bin_target_dir = Some(val),
             "LEPTOS_BIN_CARGO_COMMAND" => conf.bin_cargo_command = Some(val),
             _ if key.starts_with("LEPTOS_") => {
                 log::warn!("Env {key} is not used by cargo-leptos")

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -154,6 +154,8 @@ pub struct ProjectConfig {
     pub bin_target: String,
     /// the bin output target triple to use for building the server
     pub bin_target_triple: Option<String>,
+    /// the directory to put the generated server artifacts
+    pub bin_target_dir: Option<String>,
     /// the command to run instead of "cargo" when building the server
     pub bin_cargo_command: Option<String>,
     #[serde(default)]

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -154,6 +154,8 @@ pub struct ProjectConfig {
     pub bin_target: String,
     /// the bin output target triple to use for building the server
     pub bin_target_triple: Option<String>,
+    /// the command to run instead of "cargo" when building the server
+    pub bin_cargo_command: Option<String>,
     #[serde(default)]
     pub features: Vec<String>,
     #[serde(default)]


### PR DESCRIPTION
Suppor for alternate commands instead of 'cargo' when building the server as well as configuring the target directory for the server.

Closes #149 