### PR TITLE
Show where the app is served on startup

### DIFF
--- a/src/service/serve.rs
+++ b/src/service/serve.rs
@@ -105,7 +105,20 @@ impl ServerProcess {
             };
 
             log::debug!("Serve running {}", GRAY.paint(bin_path.as_str()));
-            Some(Command::new(bin_path).envs(self.envs.clone()).spawn()?)
+            let cmd = Some(Command::new(bin_path).envs(self.envs.clone()).spawn()?);
+            let port = self
+                .envs
+                .iter()
+                .find_map(|(k, v)| {
+                    if k == &"LEPTOS_SITE_ADDR" {
+                        Some(v.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default();
+            log::info!("Serving at http://{port}");
+            cmd
         } else {
             log::debug!("Serve no exe found {}", GRAY.paint(bin.as_str()));
             None


### PR DESCRIPTION
Started a new project with `cargo leptos new --git leptos-rs/start` had to guess it was at port 3000. This adds a message to the bottom of the startup output:
<img width="845" alt="Screenshot 2023-07-16 at 4 09 05 PM" src="https://github.com/leptos-rs/cargo-leptos/assets/123515925/9500434b-d4ea-4026-a9b9-9bb2cc1972bf">

No worries if this isn't wanted/needed or if it's implemented in a non-ideal way. Feel free to delete the PR or lemme know how to make it better!