### PR TITLE
Respect Cargo target directory configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "lightningcss",
  "log",
  "notify",
+ "pathdiff",
  "reqwest",
  "seahash",
  "semver",
@@ -1778,6 +1779,9 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+dependencies = [
+ "camino",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ tar = "0.4"
 dunce = "1.0"
 bytes = "1.4"
 leptos_hot_reload = { git = "https://github.com/leptos-rs/leptos", version = "0.4.8" }
+pathdiff = { version = "0.2.1", features = ["camino"] }
 semver = "1.0.18"
 async-trait = "0.1.72"
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ output-name = "myproj"
 # NOTE: It is relative to the workspace root when running in a workspace.
 # WARNING: all content of this folder will be erased on a rebuild.
 #
-# Optional, defaults to "target/site". Env: LEPTOS_SITE_ROOT.
+# Optional, defaults to "/site" in the Cargo target directory. Env: LEPTOS_SITE_ROOT.
 site-root = "target/site"
 
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written.

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -67,7 +67,6 @@ pub fn build_cargo_front_cmd(
         cmd.to_string(),
         format!("--package={}", proj.lib.name.as_str()),
         "--lib".to_string(),
-        "--target-dir=target/front".to_string(),
     ];
     if wasm {
         args.push("--target=wasm32-unknown-unknown".to_string());

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -69,10 +69,9 @@ pub fn build_cargo_server_cmd(
     if cmd != "test" {
         args.push(format!("--bin={}", proj.bin.target))
     }
-    args.push(format!(
-        "--target-dir={}",
-        proj.bin.target_dir.as_deref().unwrap_or("target/server")
-    ));
+    if let Some(target_dir) = &proj.bin.target_dir {
+        args.push(format!("--target-dir={target_dir}"));
+    }
     if let Some(triple) = &proj.bin.target_triple {
         args.push(format!("--target={triple}"));
     }

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -49,12 +49,12 @@ fn test_project_dev() {
     LEPTOS_WATCH=ON";
     assert_eq!(ENV_REF, envs);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --target-dir=target/server --no-default-features --features=ssr");
+    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --lib --target-dir=target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate");
+    assert_display_snapshot!(cargo, @"cargo build --package=example --lib --target=wasm32-unknown-unknown --no-default-features --features=hydrate");
 }
 
 #[test]
@@ -65,12 +65,12 @@ fn test_project_release() {
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --target-dir=target/server --no-default-features --features=ssr --release");
+    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr --release");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --lib --target-dir=target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate --release");
+    assert_display_snapshot!(cargo, @"cargo build --package=example --lib --target=wasm32-unknown-unknown --no-default-features --features=hydrate --release");
 }
 
 #[test]
@@ -105,14 +105,14 @@ fn test_workspace_project1() {
 
     assert_eq!(ENV_REF, envs);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=server-package --bin=server-package --target-dir=target/server --no-default-features");
+    assert_display_snapshot!(cargo, @"cargo build --package=server-package --bin=server-package --no-default-features");
 
     let mut command = Command::new("cargo");
     let (envs, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
 
     assert_eq!(ENV_REF, envs);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=front-package --lib --target-dir=target/front --target=wasm32-unknown-unknown --no-default-features");
+    assert_display_snapshot!(cargo, @"cargo build --package=front-package --lib --target=wasm32-unknown-unknown --no-default-features");
 }
 
 #[test]
@@ -123,10 +123,10 @@ fn test_workspace_project2() {
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[1], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=project2 --bin=project2 --target-dir=target/server --no-default-features --features=ssr");
+    assert_display_snapshot!(cargo, @"cargo build --package=project2 --bin=project2 --no-default-features --features=ssr");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[1], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=project2 --lib --target-dir=target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate");
+    assert_display_snapshot!(cargo, @"cargo build --package=project2 --lib --target=wasm32-unknown-unknown --no-default-features --features=hydrate");
 }

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -90,7 +90,7 @@ impl BinPackage {
             };
             let mut file = config.bin_target_dir.as_ref()
                 .map(|dir| dir.into())
-                .unwrap_or_else(|| metadata.rel_target_dir().join("server"));
+                .unwrap_or_else(|| metadata.rel_target_dir());
             if let Some(triple) = &config.bin_target_triple {
                 file = file.join(triple)
             };

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -90,6 +90,7 @@ impl BinPackage {
             };
             let mut file = config.bin_target_dir.as_ref()
                 .map(|dir| dir.into())
+                // Can't use absolute path because the path gets stored in snapshot testing, and it differs between developers
                 .unwrap_or_else(|| metadata.rel_target_dir());
             if let Some(triple) = &config.bin_target_triple {
                 file = file.join(triple)

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -67,7 +67,6 @@ impl LibPackage {
         let wasm_file = {
             let source = metadata
                 .rel_target_dir()
-                .join("front")
                 .join("wasm32-unknown-unknown")
                 .join(profile.to_string())
                 .join(name.replace('-', "_"))

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -66,6 +66,7 @@ impl LibPackage {
 
         let wasm_file = {
             let source = metadata
+                // Can't use absolute path because the path gets stored in snapshot testing, and it differs between developers
                 .rel_target_dir()
                 .join("wasm32-unknown-unknown")
                 .join(profile.to_string())

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -180,16 +180,25 @@ pub struct ProjectConfig {
 }
 
 impl ProjectConfig {
-    fn parse(dir: &Utf8Path, metadata: &serde_json::Value) -> Result<Self> {
+    fn parse(dir: &Utf8Path, metadata: &serde_json::Value, cargo_metadata: &Metadata) -> Result<Self> {
         let mut conf: ProjectConfig = serde_json::from_value(metadata.clone())?;
         conf.config_dir = dir.to_path_buf();
         let dotenvs = load_dotenvs(dir)?;
         overlay_env(&mut conf, dotenvs)?;
-        if conf.site_root == "/" || conf.site_root == "." {
+        if conf.site_root == "/" || conf.site_root == "." || conf.site_root == "CARGO_TARGET_DIR" {
             bail!(
                 "site-root cannot be '{}'. All the content is erased when building the site.",
                 conf.site_root
             );
+        }
+        if conf.site_root.starts_with("CARGO_TARGET_DIR") {
+            conf.site_root = {
+                let mut path = cargo_metadata.target_directory.clone();
+                // unwrap() should be safe because we just checked
+                let sub = conf.site_root.unbase("CARGO_TARGET_DIR".into()).unwrap();
+                path.push(sub);
+                path
+            };
         }
         if conf.site_addr.port() == conf.reload_port {
             bail!(
@@ -212,11 +221,12 @@ impl ProjectDefinition {
     fn from_workspace(
         metadata: &serde_json::Value,
         dir: &Utf8Path,
+        cargo_metadata: &Metadata,
     ) -> Result<Vec<(Self, ProjectConfig)>> {
         let mut found = Vec::new();
         if let Some(arr) = metadata.as_array() {
             for section in arr {
-                let conf = ProjectConfig::parse(dir, section)?;
+                let conf = ProjectConfig::parse(dir, section, cargo_metadata)?;
                 let def: Self = serde_json::from_value(section.clone())?;
                 found.push((def, conf))
             }
@@ -228,8 +238,9 @@ impl ProjectDefinition {
         package: &Package,
         metadata: &serde_json::Value,
         dir: &Utf8Path,
+        cargo_metadata: &Metadata,
     ) -> Result<(Self, ProjectConfig)> {
-        let conf = ProjectConfig::parse(dir, metadata)?;
+        let conf = ProjectConfig::parse(dir, metadata, cargo_metadata)?;
 
         ensure!(
             package.cdylib_target().is_some(),
@@ -256,7 +267,7 @@ impl ProjectDefinition {
         let workspace_dir = &metadata.workspace_root;
         let mut found: Vec<(Self, ProjectConfig)> =
             if let Some(md) = leptos_metadata(&metadata.workspace_metadata) {
-                Self::from_workspace(md, &Utf8PathBuf::default())?
+                Self::from_workspace(md, &Utf8PathBuf::default(), metadata)?
             } else {
                 Default::default()
             };
@@ -264,8 +275,8 @@ impl ProjectDefinition {
         for package in metadata.workspace_packages() {
             let dir = package.manifest_path.unbase(workspace_dir)?.without_last();
 
-            if let Some(metadata) = leptos_metadata(&package.metadata) {
-                found.push(Self::from_project(package, metadata, &dir)?);
+            if let Some(leptos_metadata) = leptos_metadata(&package.metadata) {
+                found.push(Self::from_project(package, leptos_metadata, &dir, metadata)?);
             }
         }
         Ok(found)
@@ -285,7 +296,7 @@ fn default_pkg_dir() -> Utf8PathBuf {
 }
 
 fn default_site_root() -> Utf8PathBuf {
-    Utf8PathBuf::from("target").join("site")
+    Utf8PathBuf::from("CARGO_TARGET_DIR").join("site")
 }
 
 fn default_reload_port() -> u16 {

--- a/src/config/snapshots/cargo_leptos__config__tests__project.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__project.snap
@@ -10,7 +10,7 @@ Config {
                 name: "example",
                 rel_dir: ".",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/example.wasm",
+                    source: "target/wasm32-unknown-unknown/debug/example.wasm",
                     dest: "target/site/pkg/example.wasm",
                     site: "pkg/example.wasm",
                 },
@@ -30,7 +30,7 @@ Config {
             bin: BinPackage {
                 name: "example",
                 rel_dir: ".",
-                exe_file: "target/server/debug/example",
+                exe_file: "target/debug/example",
                 target: "example",
                 features: [
                     "ssr",

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -10,7 +10,7 @@ Config {
                 name: "front-package",
                 rel_dir: "project1/front",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/front_package.wasm",
+                    source: "target/wasm32-unknown-unknown/debug/front_package.wasm",
                     dest: "target/site/project1/pkg/project1.wasm",
                     site: "pkg/project1.wasm",
                 },
@@ -28,7 +28,7 @@ Config {
             bin: BinPackage {
                 name: "server-package",
                 rel_dir: "project1/server",
-                exe_file: "target/server/debug/server-package",
+                exe_file: "target/debug/server-package",
                 target: "server-package",
                 features: [],
                 default_features: false,
@@ -76,7 +76,7 @@ Config {
                 name: "project2",
                 rel_dir: "project2",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/project2.wasm",
+                    source: "target/wasm32-unknown-unknown/debug/project2.wasm",
                     dest: "target/site/project2/pkg/project2.wasm",
                     site: "pkg/project2.wasm",
                 },
@@ -96,7 +96,7 @@ Config {
             bin: BinPackage {
                 name: "project2",
                 rel_dir: "project2",
-                exe_file: "target/server/debug/project2",
+                exe_file: "target/debug/project2",
                 target: "project2",
                 features: [
                     "ssr",

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -10,7 +10,7 @@ Config {
                 name: "project2",
                 rel_dir: "project2",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/project2.wasm",
+                    source: "target/wasm32-unknown-unknown/debug/project2.wasm",
                     dest: "target/site/project2/pkg/project2.wasm",
                     site: "pkg/project2.wasm",
                 },
@@ -30,7 +30,7 @@ Config {
             bin: BinPackage {
                 name: "project2",
                 rel_dir: "project2",
-                exe_file: "target/server/debug/project2",
+                exe_file: "target/debug/project2",
                 target: "project2",
                 features: [
                     "ssr",

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -10,7 +10,7 @@ Config {
                 name: "front-package",
                 rel_dir: "project1/front",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/front_package.wasm",
+                    source: "target/wasm32-unknown-unknown/debug/front_package.wasm",
                     dest: "target/site/project1/pkg/project1.wasm",
                     site: "pkg/project1.wasm",
                 },
@@ -28,7 +28,7 @@ Config {
             bin: BinPackage {
                 name: "server-package",
                 rel_dir: "project1/server",
-                exe_file: "target/server/debug/server-package",
+                exe_file: "target/debug/server-package",
                 target: "server-package",
                 features: [],
                 default_features: false,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -10,7 +10,7 @@ Config {
                 name: "project2",
                 rel_dir: "project2",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/project2.wasm",
+                    source: "target/wasm32-unknown-unknown/debug/project2.wasm",
                     dest: "target/site/project2/pkg/project2.wasm",
                     site: "pkg/project2.wasm",
                 },
@@ -30,7 +30,7 @@ Config {
             bin: BinPackage {
                 name: "project2",
                 rel_dir: "project2",
-                exe_file: "target/server/debug/project2",
+                exe_file: "target/debug/project2",
                 target: "project2",
                 features: [
                     "ssr",

--- a/src/ext/cargo.rs
+++ b/src/ext/cargo.rs
@@ -69,10 +69,7 @@ impl MetadataExt for Metadata {
     }
 
     fn rel_target_dir(&self) -> Utf8PathBuf {
-        self.target_directory
-            .clone()
-            .unbase(&self.workspace_root)
-            .unwrap()
+        pathdiff::diff_utf8_paths(&self.target_directory, &self.workspace_root).unwrap()
     }
 
     fn package_for(&self, id: &PackageId) -> Option<&Package> {


### PR DESCRIPTION
Changes:
- Removes hard-coded `target/server` and `target/front`
	- Using the normal target directory allows for sharing build dependencies between projects, which can significantly reduce compile times
	- It is unclear why they're hardcoded separate directories in the first place
	- Removing them was easier than making them use the proper target directory
- Uses proper relative paths for bin and lib packages
	- Fixes a crash/panic when the configured target directory was outside the workspace directory
		- Fixes #74
		- Fixes #127
		- Fixes #157
		- Fixes #186
	- Adds dependency `pathdiff`
		- It can still fail, but insofar I can tell will only do so if the base path is relative and the target path is absolute
	- Absolute paths would be better:
		- No chance of failure
		- No additional dependency
		- But those break snapshot testing
- Defaults `site-root` to the `/site/` subfolder of the cargo target directory
	- That is insofar I can tell how it was intended
	- The current method is a bit clunky, but it's the best I could come up with with serde's default
		- An alternative would be to use an option and set it to `Some` in `parse()`,
		  but that would forces `Some` checks everywhere.
	- Snapshot testing survives this because the test cases always manually specify it.

Didn't manage to add additional regression tests:
- Changing the target directory has to be done through a `.cargo/config.toml` from where cargo is invoked,
  and does not take the `--manifest-path` into account
	- Known problem: https://github.com/rust-lang/cargo/issues/10098
- The tests already specify a `cwd`, though it'sn't used for the `cargo metadata` call,
  and isn't set to the directory of the actual project/workspace being tested. I can't figure out what exactly it's supposed to do,
  and I don't feel confident doing something with it.

Additional notes/things to look at that are outside the scope of this PR:
- Snapshot testing is broken for developers who have a different Cargo target directory
- clippy has complaints about cloning double references in `src/ext/path.rs`
