### PR TITLE
Improvements in the cargo leptos command infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ playwright/.cache/
 **/.env
 
 .DS_Store
+
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +378,7 @@ dependencies = [
  "once_cell",
  "reqwest",
  "seahash",
+ "semver",
  "serde",
  "serde_json",
  "tar",
@@ -1027,6 +1052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1646,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2223,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
@@ -2522,11 +2562,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio 0.8.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tar = "0.4"
 dunce = "1.0"
 bytes = "1.4"
 leptos_hot_reload = { git = "https://github.com/leptos-rs/leptos", version = "0.4.0" }
+semver = "1.0.18"
 
 [dev-dependencies]
 insta = { version = "1.23", features = ["yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ reqwest = { version = "0.11", features = [
   "__tls",
   "default-tls",
   "native-tls-crate",
+  "json",
 ], default-features = false }
 dirs = "4.0"
 camino = "1.1"

--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -62,7 +62,7 @@ pub async fn run_loop(proj: &Arc<Project>) -> Result<()> {
         // spawn separate style-update process
         tokio::spawn({
             let changes = changes.to_owned();
-            let proj = Arc::clone(&proj);
+            let proj = Arc::clone(proj);
             async move {
                 let style = compile::style(&proj, &changes).await;
                 if let Ok(Ok(Outcome::Success(Product::Style(_)))) = style.await {

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -100,6 +100,8 @@ async fn bindgen(proj: &Project) -> Result<Outcome<Product>> {
     let wasm_file = &proj.lib.wasm_file;
     let interrupt = Interrupt::subscribe_any();
 
+    log::trace!("Front compiling WASM");
+
     // see:
     // https://github.com/rustwasm/wasm-bindgen/blob/main/crates/cli-support/src/lib.rs#L95
     // https://github.com/rustwasm/wasm-bindgen/blob/main/crates/cli/src/bin/wasm-bindgen.rs#L13

--- a/src/compile/style.rs
+++ b/src/compile/style.rs
@@ -82,7 +82,7 @@ async fn build(proj: &Arc<Project>) -> Result<Outcome<Product>> {
         (Failed, _) | (_, Failed) => return Ok(Failed),
         (Success(css), Success(tw)) => format!("{css}\n{tw}"),
     };
-    Ok(Outcome::Success(process_css(proj, css).await?))
+    Ok(Success(process_css(proj, css).await?))
 }
 
 fn browser_lists(query: &str) -> Result<Option<Browsers>> {

--- a/src/compile/tailwind.rs
+++ b/src/compile/tailwind.rs
@@ -54,7 +54,7 @@ pub async fn compile_tailwind(
 }
 
 async fn create_default_tailwind_config(tw_conf: &TailwindConfig) -> Result<()> {
-    let contents = r##"/** @type {import('tailwindcss').Config} */
+    let contents = r#"/** @type {import('tailwindcss').Config} */
     module.exports = {
       content: {
         relative: true,
@@ -65,7 +65,7 @@ async fn create_default_tailwind_config(tw_conf: &TailwindConfig) -> Result<()> 
       },
       plugins: [],
     }
-    "##;
+    "#;
     fs::write(&tw_conf.config_file, contents).await
 }
 

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -2,6 +2,7 @@ use super::ProjectConfig;
 use crate::ext::anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::{env, fs};
+use crate::ext::exe;
 
 pub fn load_dotenvs(directory: &Utf8Path) -> Result<Option<Vec<(String, String)>>> {
     let candidate = directory.join(".env");
@@ -49,6 +50,12 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_BIN_TARGET_TRIPLE" => conf.bin_target_triple = Some(val),
             "LEPTOS_BIN_TARGET_DIR" => conf.bin_target_dir = Some(val),
             "LEPTOS_BIN_CARGO_COMMAND" => conf.bin_cargo_command = Some(val),
+            // put these here to suppress the warning, but there's no
+            // good way at the moment to pull the ProjectConfig all the way to Exe
+            exe::ENV_VAR_LEPTOS_TAILWIND_VERSION => {},
+            exe::ENV_VAR_LEPTOS_SASS_VERSION => {},
+            exe::ENV_VAR_LEPTOS_CARGO_GENERATE_VERSION => {},
+            exe::ENV_VAR_LEPTOS_WASM_OPT_VERSION => {},
             _ if key.starts_with("LEPTOS_") => {
                 log::warn!("Env {key} is not used by cargo-leptos")
             }

--- a/src/config/end2end.rs
+++ b/src/config/end2end.rs
@@ -11,9 +11,7 @@ pub struct End2EndConfig {
 
 impl End2EndConfig {
     pub fn resolve(config: &ProjectConfig) -> Option<Self> {
-        let Some(cmd) = &config.end2end_cmd else {
-          return None
-        };
+        let cmd = &config.end2end_cmd.to_owned()?;
 
         let dir = config.end2end_dir.to_owned().unwrap_or_default();
 

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -47,6 +47,12 @@ const DEFAULT_SASS_VERSION: &str = "1.58.3";
 const DEFAULT_WASM_OPT_VERSION: &str = "version_112";
 const DEFAULT_TAILWIND_VERSION: &str = "v3.3.3";
 
+pub const ENV_VAR_LEPTOS_CARGO_GENERATE_VERSION: &str = "LEPTOS_CARGO_GENERATE_VERSION";
+pub const ENV_VAR_LEPTOS_TAILWIND_VERSION: &str = "LEPTOS_TAILWIND_VERSION";
+pub const ENV_VAR_LEPTOS_SASS_VERSION: &str = "LEPTOS_SASS_VERSION";
+pub const ENV_VAR_LEPTOS_WASM_OPT_VERSION: &str = "LEPTOS_WASM_OPT_VERSION";
+
+
 impl ExeMeta {
 
     #[allow(clippy::wrong_self_convention)]
@@ -374,7 +380,7 @@ impl Exe {
         match &self {
             Exe::CargoGenerate => {
                 let latch = ON_STARTUP_ONCE.get(self);
-                let version = env::var("LEPTOS_CARGO_GENERATE_VERSION")
+                let version = env::var(ENV_VAR_LEPTOS_CARGO_GENERATE_VERSION)
                     .unwrap_or_else(|_| DEFAULT_CARGO_GENERATE_VERSION.into());
 
                 if let Some(latch) = latch {
@@ -387,7 +393,7 @@ impl Exe {
             },
             Exe::Sass => {
                 let latch = ON_STARTUP_ONCE.get(self);
-                let version = env::var("LEPTOS_SASS_VERSION")
+                let version = env::var(ENV_VAR_LEPTOS_SASS_VERSION)
                     .unwrap_or_else(|_| DEFAULT_SASS_VERSION.into());
 
                 if let Some(latch) = latch {
@@ -400,7 +406,7 @@ impl Exe {
             },
             Exe::WasmOpt => {
                 let latch = ON_STARTUP_ONCE.get(self);
-                let version = env::var("LEPTOS_WASM_OPT_VERSION")
+                let version = env::var(ENV_VAR_LEPTOS_WASM_OPT_VERSION)
                     .unwrap_or_else(|_| DEFAULT_WASM_OPT_VERSION.into());
 
                 if let Some(latch) = latch {
@@ -413,7 +419,7 @@ impl Exe {
             },
             Exe::Tailwind => {
                 let latch = ON_STARTUP_ONCE.get(self);
-                let version = env::var("LEPTOS_TAILWIND_VERSION")
+                let version = env::var(ENV_VAR_LEPTOS_TAILWIND_VERSION)
                     .unwrap_or_else(|_| DEFAULT_TAILWIND_VERSION.into());
 
                 if let Some(latch) = latch {

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -513,9 +513,6 @@ impl Exe {
             log::debug!("Command failed to check for the latest version");
             None
         }
-
-        // log::debug!("Command version for Tailwind resolved to {}", version);
-
     }
 
     /// Tailwind uses the 'vMaj.Min.Pat' format.
@@ -542,7 +539,7 @@ impl Exe {
                         match Version::parse(format!("{ver_string}.0").as_str()) {
                             Ok(v) => Some(v),
                             Err(e) => {
-                                log::error!("Failed to normalize version {ver_string}: {e}");
+                                log::error!("Command failed to normalize version {ver_string}: {e}");
                                 None
                             }
                         }

--- a/src/ext/tests.rs
+++ b/src/ext/tests.rs
@@ -7,7 +7,7 @@ use temp_dir::TempDir;
 async fn download_sass() {
     let dir = TempDir::new().unwrap();
     let meta = Exe::Sass.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
@@ -19,7 +19,7 @@ async fn download_sass() {
 async fn download_tailwind() {
     let dir = TempDir::new().unwrap();
     let meta = Exe::Tailwind.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let e = meta.with_cache_dir(dir.path()).await;
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
     let e = e.unwrap();
@@ -30,7 +30,7 @@ async fn download_tailwind() {
 async fn download_cargo_generate() {
     let dir = TempDir::new().unwrap();
     let meta = Exe::CargoGenerate.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
@@ -42,7 +42,7 @@ async fn download_cargo_generate() {
 async fn download_wasmopt() {
     let dir = TempDir::new().unwrap();
     let meta = Exe::WasmOpt.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 

--- a/src/ext/tests.rs
+++ b/src/ext/tests.rs
@@ -6,7 +6,7 @@ use temp_dir::TempDir;
 #[tokio::test]
 async fn download_sass() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::Sass.meta().unwrap();
+    let meta = Exe::Sass.meta().await.unwrap();
     let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
@@ -18,7 +18,7 @@ async fn download_sass() {
 #[tokio::test]
 async fn download_tailwind() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::Tailwind.meta().unwrap();
+    let meta = Exe::Tailwind.meta().await.unwrap();
     let e = meta.with_cache_dir(dir.path()).await;
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
@@ -29,7 +29,7 @@ async fn download_tailwind() {
 #[tokio::test]
 async fn download_cargo_generate() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::CargoGenerate.meta().unwrap();
+    let meta = Exe::CargoGenerate.meta().await.unwrap();
     let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
@@ -41,7 +41,7 @@ async fn download_cargo_generate() {
 #[tokio::test]
 async fn download_wasmopt() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::WasmOpt.meta().unwrap();
+    let meta = Exe::WasmOpt.meta().await.unwrap();
     let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,5 +12,5 @@ async fn main() -> Result<()> {
     }
 
     let args = Cli::parse_from(&args);
-    crate::run(args).await
+    run(args).await
 }

--- a/src/service/reload.rs
+++ b/src/service/reload.rs
@@ -101,6 +101,7 @@ async fn websocket(mut stream: WebSocket) {
     });
 }
 
+#[allow(clippy::needless_pass_by_ref_mut)]
 async fn send(stream: &mut WebSocket, msg: BrowserMessage) {
     let site_addr = *SITE_ADDR.read().await;
     if !wait_for_socket("Reload", site_addr).await {


### PR DESCRIPTION
Hi, I wanted to share some early results for #162 . Let me know if I'm moving in the right direction and am aligned with the project guidelines.

The best way to see new things in action is to do smth like:
```sh
# build the cargo-leptos project first, then create a new web project and run:
~/projects/rust/cargo-leptos/target/debug/cargo-leptos watch --hot-reload -vv
```
## Important!
Add these lines to the `Cargo.toml` in your web project, otherwise Tailwind loop won't be triggered. Doc updates are tracked in a separate issue
```
# [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
tailwind-input-file = "input.css"
```

## Summary so far
* Can now override versions and debug-report tool versions used on startup.
* Added ability to override any tool version via an env var.
* Use the current latest tailwindcss version v3.3.3, still hardcoded for now.
* Properly handle tool download errors and halt.
* Report the binary command cache dir location on startup (once).
* Addressed Cippy linter suggestions and suppressed where applicable.