### PR TITLE
Exit serve command if child process exits

### DIFF
--- a/src/command/serve.rs
+++ b/src/command/serve.rs
@@ -8,7 +8,7 @@ pub async fn serve(proj: &Arc<Project>) -> Result<()> {
     if !super::build::build_proj(proj).await.dot()? {
         return Ok(());
     }
-    let server = serve::spawn(proj).await;
+    let server = serve::spawn_oneshot(proj).await;
     server.await??;
     Ok(())
 }


### PR DESCRIPTION
Currently, `serve` and `watch` share an underlying server which causes `serve` to wait for ctrl+c to be pressed, even if the underlying process has gracefully exited.

This PR makes `serve` behave as a one-shot and exit if its underlying process terminates, while preserving the reload functionality of the `watch` command.