### PR TITLE
Improved commands sub-system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ playwright/.cache/
 **/.env
 
 .DS_Store
+
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,13 +131,13 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -187,6 +196,21 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -333,6 +357,7 @@ version = "0.1.11"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "async-trait",
  "axum",
  "bytes",
  "camino",
@@ -354,6 +379,7 @@ dependencies = [
  "once_cell",
  "reqwest",
  "seahash",
+ "semver",
  "serde",
  "serde_json",
  "tar",
@@ -454,7 +480,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -618,7 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1027,6 +1053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1394,7 @@ dependencies = [
  "quote",
  "rstml",
  "serde",
- "syn 2.0.18",
+ "syn 2.0.27",
  "walkdir",
 ]
 
@@ -1618,6 +1650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,7 +1687,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1815,7 +1856,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1880,9 +1921,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1895,7 +1936,7 @@ checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
  "version_check",
  "yansi",
 ]
@@ -1922,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2116,7 +2157,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
  "syn_derive",
  "thiserror",
 ]
@@ -2223,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
@@ -2258,7 +2299,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2410,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2428,7 +2469,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2491,7 +2532,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2522,11 +2563,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio 0.8.8",
@@ -2547,7 +2589,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2818,7 +2860,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -2884,7 +2926,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ reqwest = { version = "0.11", features = [
   "__tls",
   "default-tls",
   "native-tls-crate",
+  "json",
 ], default-features = false }
 dirs = "4.0"
 camino = "1.1"
@@ -63,6 +64,8 @@ tar = "0.4"
 dunce = "1.0"
 bytes = "1.4"
 leptos_hot_reload = { git = "https://github.com/leptos-rs/leptos", version = "0.4.0" }
+semver = "1.0.18"
+async-trait = "0.1.72"
 
 [dev-dependencies]
 insta = { version = "1.23", features = ["yaml"] }

--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -62,7 +62,7 @@ pub async fn run_loop(proj: &Arc<Project>) -> Result<()> {
         // spawn separate style-update process
         tokio::spawn({
             let changes = changes.to_owned();
-            let proj = Arc::clone(&proj);
+            let proj = Arc::clone(proj);
             async move {
                 let style = compile::style(&proj, &changes).await;
                 if let Ok(Ok(Outcome::Success(Product::Style(_)))) = style.await {

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -100,6 +100,8 @@ async fn bindgen(proj: &Project) -> Result<Outcome<Product>> {
     let wasm_file = &proj.lib.wasm_file;
     let interrupt = Interrupt::subscribe_any();
 
+    log::info!("Front compiling WASM");
+
     // see:
     // https://github.com/rustwasm/wasm-bindgen/blob/main/crates/cli-support/src/lib.rs#L95
     // https://github.com/rustwasm/wasm-bindgen/blob/main/crates/cli/src/bin/wasm-bindgen.rs#L13

--- a/src/compile/style.rs
+++ b/src/compile/style.rs
@@ -82,7 +82,7 @@ async fn build(proj: &Arc<Project>) -> Result<Outcome<Product>> {
         (Failed, _) | (_, Failed) => return Ok(Failed),
         (Success(css), Success(tw)) => format!("{css}\n{tw}"),
     };
-    Ok(Outcome::Success(process_css(proj, css).await?))
+    Ok(Success(process_css(proj, css).await?))
 }
 
 fn browser_lists(query: &str) -> Result<Option<Browsers>> {

--- a/src/compile/tailwind.rs
+++ b/src/compile/tailwind.rs
@@ -54,7 +54,7 @@ pub async fn compile_tailwind(
 }
 
 async fn create_default_tailwind_config(tw_conf: &TailwindConfig) -> Result<()> {
-    let contents = r##"/** @type {import('tailwindcss').Config} */
+    let contents = r#"/** @type {import('tailwindcss').Config} */
     module.exports = {
       content: {
         relative: true,
@@ -65,7 +65,7 @@ async fn create_default_tailwind_config(tw_conf: &TailwindConfig) -> Result<()> 
       },
       plugins: [],
     }
-    "##;
+    "#;
     fs::write(&tw_conf.config_file, contents).await
 }
 

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -2,6 +2,7 @@ use super::ProjectConfig;
 use crate::ext::anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::{env, fs};
+use crate::ext::exe;
 
 pub fn load_dotenvs(directory: &Utf8Path) -> Result<Option<Vec<(String, String)>>> {
     let candidate = directory.join(".env");
@@ -49,6 +50,12 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_BIN_TARGET_TRIPLE" => conf.bin_target_triple = Some(val),
             "LEPTOS_BIN_TARGET_DIR" => conf.bin_target_dir = Some(val),
             "LEPTOS_BIN_CARGO_COMMAND" => conf.bin_cargo_command = Some(val),
+            // put these here to suppress the warning, but there's no
+            // good way at the moment to pull the ProjectConfig all the way to Exe
+            exe::ENV_VAR_LEPTOS_TAILWIND_VERSION => {},
+            exe::ENV_VAR_LEPTOS_SASS_VERSION => {},
+            exe::ENV_VAR_LEPTOS_CARGO_GENERATE_VERSION => {},
+            exe::ENV_VAR_LEPTOS_WASM_OPT_VERSION => {},
             _ if key.starts_with("LEPTOS_") => {
                 log::warn!("Env {key} is not used by cargo-leptos")
             }

--- a/src/config/end2end.rs
+++ b/src/config/end2end.rs
@@ -11,9 +11,7 @@ pub struct End2EndConfig {
 
 impl End2EndConfig {
     pub fn resolve(config: &ProjectConfig) -> Option<Self> {
-        let Some(cmd) = &config.end2end_cmd else {
-          return None
-        };
+        let cmd = &config.end2end_cmd.to_owned()?;
 
         let dir = config.end2end_dir.to_owned().unwrap_or_default();
 

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -7,24 +7,44 @@ use std::{
     fs::{self, File},
     io::{Cursor, Write},
     path::{Path, PathBuf},
+    sync::Once,
 };
+
+use std::env;
+
 use zip::ZipArchive;
 
 use super::util::{is_linux_musl_env, os_arch};
 
 #[cfg(target_family = "unix")]
 use std::os::unix::prelude::PermissionsExt;
+use std::time::{Duration, SystemTime};
+use reqwest::ClientBuilder;
+
+use semver::{Version};
 
 #[derive(Debug)]
 pub struct ExeMeta {
     name: &'static str,
-    version: &'static str,
+    version: String,
     url: String,
     exe: String,
-    manual: &'static str,
+    manual: String,
 }
 
+lazy_static::lazy_static!{
+    static ref ON_STARTUP_DEBUG_ONCE: Once = Once::new();
+}
+
+pub const ENV_VAR_LEPTOS_CARGO_GENERATE_VERSION: &str = "LEPTOS_CARGO_GENERATE_VERSION";
+pub const ENV_VAR_LEPTOS_TAILWIND_VERSION: &str = "LEPTOS_TAILWIND_VERSION";
+pub const ENV_VAR_LEPTOS_SASS_VERSION: &str = "LEPTOS_SASS_VERSION";
+pub const ENV_VAR_LEPTOS_WASM_OPT_VERSION: &str = "LEPTOS_WASM_OPT_VERSION";
+
+
 impl ExeMeta {
+
+    #[allow(clippy::wrong_self_convention)]
     fn from_global_path(&self) -> Option<PathBuf> {
         which::which(self.name).ok()
     }
@@ -75,8 +95,13 @@ impl<'a> ExeCache<'a> {
             self.meta.name,
             GRAY.paint(&self.meta.url)
         );
-        let data = reqwest::get(&self.meta.url).await?.bytes().await?;
-        Ok(data)
+
+        let response = reqwest::get(&self.meta.url).await?;
+
+        match response.status().is_success() {
+            true => Ok(response.bytes().await?),
+            false => bail!("Could not download from {}", self.meta.url),
+        }
     }
 
     fn extract_downloaded(&self, data: &Bytes) -> Result<()> {
@@ -177,12 +202,17 @@ fn get_cache_dir() -> Result<PathBuf> {
         .join("cargo-leptos");
 
     if !dir.exists() {
-        std::fs::create_dir_all(&dir).context(format!("Could not create dir {dir:?}"))?;
+        fs::create_dir_all(&dir).context(format!("Could not create dir {dir:?}"))?;
     }
+
+    ON_STARTUP_DEBUG_ONCE.call_once(|| {
+        log::debug!("Command cache dir: {}", dir.to_string_lossy());
+    });
 
     Ok(dir)
 }
 
+#[derive(Debug, Hash, Eq, PartialEq)]
 pub enum Exe {
     CargoGenerate,
     Sass,
@@ -192,7 +222,7 @@ pub enum Exe {
 
 impl Exe {
     pub async fn get(&self) -> Result<PathBuf> {
-        let meta = self.meta()?;
+        let meta = self.meta().await?;
 
         let path = if let Some(path) = meta.from_global_path() {
             path
@@ -203,7 +233,7 @@ impl Exe {
         };
 
         log::debug!(
-            "Command using {} {}. {}",
+            "Command using {} {} {}",
             &meta.name,
             &meta.version,
             GRAY.paint(path.to_string_lossy())
@@ -212,121 +242,480 @@ impl Exe {
         Ok(path)
     }
 
-    pub fn meta(&self) -> Result<ExeMeta> {
+    pub async fn meta(&self) -> Result<ExeMeta> {
         let (target_os, target_arch) = os_arch().unwrap();
 
         let exe = match self {
-            Exe::CargoGenerate => {
-                // There's a problem with upgrading cargo-generate because the tar file cannot be extracted
-                // due to missing support for https://github.com/alexcrichton/tar-rs/pull/298
-                // The tar extracts ok, but contains a folder `GNUSparseFile.0` which contains a file `cargo-generate`
-                // that has not been fully extracted.
-                let version = "0.17.3";
-
-                let target = match (target_os, target_arch) {
-                    ("macos", "aarch64") => "aarch64-apple-darwin",
-                    ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
-                    ("macos", "x86_64") => "x86_64-apple-darwin",
-                    ("windows", "x86_64") => "x86_64-pc-windows-msvc",
-                    ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
-                    _ => bail!("No cargo-generate tar binary found for {target_os} {target_arch}"),
-                };
-
-                let exe = match target_os {
-                    "windows" => "cargo-generate.exe".to_string(),
-                    _ => "cargo-generate".to_string(),
-                };
-                let url = format!("https://github.com/cargo-generate/cargo-generate/releases/download/v{version}/cargo-generate-v{version}-{target}.tar.gz");
-                ExeMeta {
-                    name: "cargo-generate",
-                    version,
-                    url,
-                    exe,
-                    manual: "Try manually installing cargo-generate: https://github.com/cargo-generate/cargo-generate#installation"
-                }
-            }
-            Exe::Sass => {
-                let version = "1.58.3";
-                let is_musl_env = is_linux_musl_env();
-                let url = if is_musl_env {
-                    match target_arch {
-                        "x86_64" => format!("https://github.com/dart-musl/dart-sass/releases/download/{version}/dart-sass-{version}-linux-x64.tar.gz"),
-                        "aarch64" => format!("https://github.com/dart-musl/dart-sass/releases/download/{version}/dart-sass-{version}-linux-arm64.tar.gz"),
-                        _ => bail!("No sass tar binary found for linux-musl {target_arch}")
-                    }
-                } else {
-                    match (target_os, target_arch) {
-                        ("windows", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-windows-x64.zip"),
-                        ("macos" | "linux", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-x64.tar.gz"),
-                        ("macos" | "linux", "aarch64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-arm64.tar.gz"),
-                        _ => bail!("No sass tar binary found for {target_os} {target_arch}")
-                    }
-                };
-                let exe = match target_os {
-                    "windows" => "dart-sass/sass.bat".to_string(),
-                    _ => "dart-sass/sass".to_string(),
-                };
-                ExeMeta {
-                    name: "sass",
-                    version,
-                    url,
-                    exe,
-                    manual: "Try manually installing sass: https://sass-lang.com/install",
-                }
-            }
-            Exe::WasmOpt => {
-                let version = "version_112";
-                let target = match (target_os, target_arch) {
-                    ("linux", _) => "x86_64-linux",
-                    ("windows", _) => "x86_64-windows",
-                    ("macos", "aarch64") => "arm64-macos",
-                    ("macos", "x86_64") => "x86_64-macos",
-                    _ => {
-                        bail!("No wasm-opt tar binary found for {target_os} {target_arch}")
-                    }
-                };
-                let url = format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-{target}.tar.gz");
-
-                let exe = match target_os {
-                    "windows" => format!("binaryen-{version}/bin/wasm-opt.exe"),
-                    _ => format!("binaryen-{version}/bin/wasm-opt"),
-                };
-                ExeMeta {
-                    name: "wasm-opt",
-                    version,
-                    url,
-                    exe,
-                    manual:
-                        "Try manually installing binaryen: https://github.com/WebAssembly/binaryen",
-                }
-            }
-            Exe::Tailwind => {
-                let version = "v3.3.1";
-                let url = match (target_os, target_arch) {
-                    ("windows", "x86_64") => format!("https://github.com/tailwindlabs/tailwindcss/releases/download/{version}/tailwindcss-windows-x64.exe"),
-                    ("macos", "x86_64") => format!("https://github.com/tailwindlabs/tailwindcss/releases/download/{version}/tailwindcss-macos-x64"),
-                    ("macos", "aarch64") => format!("https://github.com/tailwindlabs/tailwindcss/releases/download/{version}/tailwindcss-macos-arm64"),
-                    ("linux", "x86_64") => format!("https://github.com/tailwindlabs/tailwindcss/releases/download/{version}/tailwindcss-linux-x64"),
-                    ("linux", "aarch64") => format!("https://github.com/tailwindlabs/tailwindcss/releases/download/{version}/tailwindcss-linux-arm64"),
-                    _ => bail!("No tailwind binary found for {target_os} {target_arch}")
-                };
-                let exe = match (target_os, target_arch) {
-                    ("windows", _) => "tailwindcss-windows-x64.exe".to_string(),
-                    ("macos", "x86_64") => "tailwindcss-macos-x64".to_string(),
-                    ("macos", "aarch64") => "tailwindcss-macos-arm64".to_string(),
-                    ("linux", "x86_64") => "tailwindcss-linux-x64".to_string(),
-                    (_, _) => "tailwindcss-linux-arm64".to_string(),
-                };
-                ExeMeta {
-                    name: "tailwindcss",
-                    version,
-                    url,
-                    exe,
-                    manual: "Try manually installing tailwindcss",
-                }
-            }
+            // There's a problem with upgrading cargo-generate because the tar file cannot be extracted
+            // due to missing support for https://github.com/alexcrichton/tar-rs/pull/298
+            // The tar extracts ok, but contains a folder `GNUSparseFile.0` which contains a file `cargo-generate`
+            // that has not been fully extracted.
+            // let command = &CommandCargoGenerate as &dyn Command;
+            Exe::CargoGenerate => CommandCargoGenerate.exe_meta(target_os, target_arch).await.dot()?,
+            Exe::Sass => CommandSass.exe_meta(target_os, target_arch).await.dot()?,
+            Exe::WasmOpt => CommandWasmOpt.exe_meta(target_os, target_arch).await.dot()?,
+            Exe::Tailwind => CommandTailwind.exe_meta(target_os, target_arch).await.dot()?,
         };
 
         Ok(exe)
+    }
+}
+
+// fallback to this crate until rust stable includes async traits
+// https://github.com/dtolnay/async-trait
+use async_trait::async_trait;
+
+struct CommandTailwind;
+struct CommandWasmOpt;
+struct CommandSass;
+struct CommandCargoGenerate;
+
+#[async_trait]
+impl Command for CommandTailwind {
+    fn name(&self) -> &'static str { "tailwindcss" }
+    fn default_version(&self) -> &'static str { "v3.3.3" }
+    fn env_var_version_name(&self) -> &'static str { ENV_VAR_LEPTOS_TAILWIND_VERSION }
+    fn github_owner(&self) -> &'static str { "tailwindlabs" }
+    fn github_repo(&self) -> &'static str { "tailwindcss" }
+
+    /// Tool binary download url for the given OS and platform arch
+    fn download_url(&self, target_os: &str, target_arch: &str, version: &str) -> Result<String> {
+        match (target_os, target_arch) {
+            ("windows", "x86_64") => Ok(format!("https://github.com/{}/{}/releases/download/{}/{}-windows-x64.exe",
+                                            self.github_owner(), self.github_repo(), version, self.name())),
+            ("macos", "x86_64") => Ok(format!("https://github.com/{}/{}/releases/download/{}/{}-macos-x64",
+                                           self.github_owner(), self.github_repo(), version, self.name())),
+            ("macos", "aarch64") => Ok(format!("https://github.com/{}/{}/releases/download/{}/{}-macos-arm64",
+                                            self.github_owner(), self.github_repo(), version, self.name())),
+            ("linux", "x86_64") => Ok(format!("https://github.com/{}/{}/releases/download/{}/{}-linux-x64",
+                                           self.github_owner(), self.github_repo(), version, self.name())),
+            ("linux", "aarch64") => Ok(format!("https://github.com/{}/{}/releases/download/{}/{}-linux-arm64",
+                                            self.github_owner(), self.github_repo(), version, self.name())),
+            _ => bail!("Command [{}] failed to find a match for {}-{} ", self.name(), target_os, target_arch),
+        }
+    }
+
+    fn executable_name(&self, target_os: &str, target_arch: &str, _version: Option<&str>) -> Result<String> {
+        Ok(match (target_os, target_arch) {
+            ("windows", _) => format!("{}-windows-x64.exe", self.name()),
+            ("macos", "x86_64") => format!("{}-macos-x64", self.name()),
+            ("macos", "aarch64") => format!("{}-macos-arm64", self.name()),
+            ("linux", "x86_64") => format!("{}-linux-x64", self.name()),
+            (_, _) => format!("{}-linux-arm64", self.name()),
+        })
+    }
+
+    fn manual_install_instructions(&self) -> String {
+        "Try manually installing tailwindcss: https://tailwindcss.com/docs/installation".to_string()
+    }
+}
+
+#[async_trait]
+impl Command for CommandWasmOpt {
+    fn name(&self) -> &'static str { "wasm-opt" }
+    fn default_version(&self) -> &'static str { "version_112" }
+    fn env_var_version_name(&self) -> &'static str { ENV_VAR_LEPTOS_WASM_OPT_VERSION }
+    fn github_owner(&self) -> &'static str { "WebAssembly" }
+    fn github_repo(&self) -> &'static str { "binaryen" }
+
+    fn download_url(&self, target_os: &str, target_arch: &str, version: &str) -> Result<String> {
+        let target = match (target_os, target_arch) {
+            ("linux", _) => "x86_64-linux",
+            ("windows", _) => "x86_64-windows",
+            ("macos", "aarch64") => "arm64-macos",
+            ("macos", "x86_64") => "x86_64-macos",
+            _ => {
+                bail!("No wasm-opt tar binary found for {target_os} {target_arch}")
+            }
+        };
+
+        Ok(format!(
+            "https://github.com/{}/{}/releases/download/{}/binaryen-{}-{}.tar.gz",
+            self.github_owner(),
+            self.github_repo(),
+            version,
+            version,
+            target)
+        )
+    }
+
+    fn executable_name(&self, target_os: &str, _target_arch: &str, version: Option<&str>) -> Result<String> {
+        if version.is_none() { bail!("Version is required for WASM Opt, none provided")};
+
+        Ok(match target_os {
+            "windows" => format!("binaryen-{}/bin/{}.exe", version.unwrap_or_default(), self.name()),
+            _ => format!("binaryen-{}/bin/{}", version.unwrap_or_default(), self.name()),
+        })
+    }
+
+    fn manual_install_instructions(&self) -> String {
+        "Try manually installing binaryen: https://github.com/WebAssembly/binaryen".to_string()
+    }
+}
+
+#[async_trait]
+impl Command for CommandSass {
+    fn name(&self) -> &'static str { "sass" }
+    fn default_version(&self) -> &'static str { "1.58.3" }
+    fn env_var_version_name(&self) -> &'static str { ENV_VAR_LEPTOS_SASS_VERSION }
+    fn github_owner(&self) -> &'static str { "dart-musl" }
+    fn github_repo(&self) -> &'static str { "dart-sass" }
+
+    fn download_url(&self, target_os: &str, target_arch: &str, version: &str) -> Result<String> {
+        let is_musl_env = is_linux_musl_env();
+        Ok(if is_musl_env {
+            match target_arch {
+                "x86_64" => format!(
+                    "https://github.com/{}/{}/releases/download/{}/dart-sass-{}-linux-x64.tar.gz",
+                    self.github_owner(), self.github_repo(), version, version
+                ),
+                "aarch64" => format!(
+                    "https://github.com/{}/{}/releases/download/{}/dart-sass-{}-linux-arm64.tar.gz"
+                    , self.github_owner(), self.github_repo(), version, version
+                ),
+                _ => bail!("No sass tar binary found for linux-musl {target_arch}")
+            }
+        } else {
+            match (target_os, target_arch) {
+                // note the different github_owner
+                ("windows", "x86_64") => format!(
+                    "https://github.com/sass/{}/releases/download/{}/dart-sass-{}-windows-x64.zip",
+                    self.github_repo(), version, version
+                ),
+                ("macos" | "linux", "x86_64") => format!(
+                    "https://github.com/sass/{}/releases/download/{}/dart-sass-{}-{}-x64.tar.gz",
+                    self.github_repo(), version, version, target_os
+                ),
+                ("macos" | "linux", "aarch64") => format!(
+                    "https://github.com/sass/{}/releases/download/{}/dart-sass-{}-{}-arm64.tar.gz",
+                    self.github_repo(), version, version, target_os
+                ),
+                _ => bail!("No sass tar binary found for {target_os} {target_arch}")
+            }
+        })
+    }
+
+    fn executable_name(&self, target_os: &str, _target_arch: &str, _version: Option<&str>) -> Result<String> {
+        Ok(match target_os {
+            "windows" => "dart-sass/sass.bat".to_string(),
+            _ => "dart-sass/sass".to_string(),
+        })
+    }
+
+    fn manual_install_instructions(&self) -> String {
+        "Try manually installing sass: https://sass-lang.com/install".to_string()
+    }
+}
+
+#[async_trait]
+impl Command for CommandCargoGenerate {
+    fn name(&self) -> &'static str {"cargo-generate"}
+    fn default_version(&self) -> &'static str { "v0.17.3" }
+    fn env_var_version_name(&self) -> &'static str { ENV_VAR_LEPTOS_CARGO_GENERATE_VERSION }
+    fn github_owner(&self) -> &'static str { "cargo-generate" }
+    fn github_repo(&self) -> &'static str { "cargo-generate" }
+
+    fn download_url(&self, target_os: &str, target_arch: &str, version: &str) -> Result<String> {
+        let target = match (target_os, target_arch) {
+            ("macos", "aarch64") => "aarch64-apple-darwin",
+            ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
+            ("macos", "x86_64") => "x86_64-apple-darwin",
+            ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+            ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
+            _ => bail!("No cargo-generate tar binary found for {target_os} {target_arch}"),
+        };
+
+        Ok(format!(
+            "https://github.com/{}/{}/releases/download/v{}/cargo-generate-v{}-{}.tar.gz",
+            self.github_owner(),
+            self.github_repo(),
+            version, version,
+            target
+        ))
+    }
+
+    fn executable_name(&self, target_os: &str, _target_arch: &str, _version: Option<&str>) -> Result<String> {
+        Ok(match target_os {
+            "windows" => "cargo-generate.exe".to_string(),
+            _ => "cargo-generate".to_string(),
+        })
+    }
+
+    fn manual_install_instructions(&self) -> String {
+        "Try manually installing cargo-generate: https://github.com/cargo-generate/cargo-generate#installation".to_string()
+    }
+}
+
+#[async_trait]
+/// Template trait, implementors should only fill in
+/// the command-specific logic. Handles caching, latest
+/// version checking against the GitHub API and env var
+/// version override for a given command.
+trait Command {
+    fn name(&self) -> &'static str;
+    fn default_version(&self) -> &str;
+    fn env_var_version_name(&self) -> &str;
+    fn github_owner(&self) -> &str;
+    fn github_repo(&self) -> &str;
+    fn download_url(&self, target_os: &str, target_arch: &str, version: &str) -> Result<String>;
+    fn executable_name(&self, target_os: &str, target_arch: &str, version: Option<&str>) -> Result<String>;
+    #[allow(unused)]
+    fn manual_install_instructions(&self) -> String {
+        // default placeholder text, individual commands can override and customize
+        "Try manually installing the command".to_string()
+    }
+
+    /// Resolves and creates command metadata.
+    /// Checks if a newer version of the binary is available (once a day).
+    /// A marker file is created in the cache directory. Add `-v` flag to
+    /// the `cargo leptos` command to see the OS-specific location.
+    ///
+    /// # Arguments
+    ///
+    /// * `target_os` - The target operating system.
+    /// * `target_arch` - The target architecture.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the `ExeMeta` struct on success, or an error on failure.
+    ///
+    async fn exe_meta(&self, target_os: &str, target_arch: &str) -> Result<ExeMeta> {
+        let version = self.resolve_version().await;
+        let url = self.download_url(target_os, target_arch, version.as_str())?;
+        let exe = self.executable_name(target_os, target_arch, Some(version.as_str()))?;
+        Ok(ExeMeta {
+            name: self.name(),
+            version,
+            url: url.to_owned(),
+            exe: exe.to_string(),
+            manual: self.manual_install_instructions(),
+        })
+    }
+
+    /// Returns true if the command should check for a new version
+    /// Returns false in case of any errors (no check)
+    async fn should_check_for_new_version(&self) -> bool {
+        match get_cache_dir() {
+            Ok(dir) => {
+                let marker = dir.join(format!(".{}_last_checked", self.name()));
+                return match (marker.exists(), marker.is_dir()) {
+                    (_, true) => { // conflicting dir instead of a marker file, bail
+                        log::warn!("Command [{}] encountered a conflicting dir in the cache, please delete {}",
+                            self.name(), marker.display());
+
+                            false
+                    },
+                    (true, _) => { // existing marker file, read and check if last checked > 1 DAY
+                        let contents = tokio::fs::read_to_string(&marker).await;
+                        let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
+                        if let Some(timestamp) =
+                            contents.ok()
+                                .map(|s| s.parse::<u64>().ok().unwrap_or_default()) {
+                            let last_checked = Duration::from_millis(timestamp);
+                            let one_day = Duration::from_secs(24 * 60 * 60);
+                            if let Ok(now) = now {
+                                match (now - last_checked) > one_day {
+                                    true => tokio::fs::write(&marker, now.as_millis().to_string()).await.is_ok(),
+                                    false => false,
+                                }
+                            } else { false }
+                        } else { false }
+                    },
+                    (false, _) => { // no marker file yet, record and hint to check
+                        let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
+                        return if let Ok(unix_timestamp) = now {
+                            tokio::fs::write(marker, unix_timestamp.as_millis().to_string()).await.is_ok()
+                        } else {
+                            false
+                        }
+                    }
+                }
+            },
+            Err(e) => {
+                log::warn!("Command {} failed to get cache dir: {}", self.name(), e);
+                false
+            }
+        }
+    }
+
+
+    async fn check_for_latest_version(&self) -> Option<String> {
+        log::debug!("Command [{}] checking for the latest available version", self.name());
+
+        let client = ClientBuilder::default()
+            // this github api allows anonymous, but requires a user-agent header be set
+            .user_agent("cargo-leptos")
+            .build()
+            .unwrap_or_default();
+
+        if let Ok(response) = client.get(
+            format!("https://api.github.com/repos/{}/{}/releases/latest", self.github_owner(), self.github_repo()))
+            .send().await {
+
+            if !response.status().is_success() {
+                log::error!("Command [{}] GitHub API request failed: {}", self.name(), response.status());
+                return None
+            }
+
+            #[derive(serde::Deserialize)]
+            struct Github {
+                tag_name: String, // this is the version number, not the git tag
+            }
+
+            let github: Github = match response.json().await {
+                Ok(json) => json,
+                Err(e) => {
+                    log::debug!("Command [{}] failed to parse the response JSON from the GitHub API: {}", self.name(), e);
+                    return None
+                }
+            };
+
+            Some(github.tag_name)
+        } else {
+            log::debug!("Command [{}] failed to check for the latest version", self.name());
+            None
+        }
+    }
+
+    /// get the latest version from github api
+    /// cache the last check timestamp
+    /// compare with the currently requested version
+    /// inform a user if a more recent compatible version is available
+    async fn resolve_version(&self) -> String { // 'static self is odd, but required for an async closure below
+        // TODO revisit this logic when implementing the SemVer compatible ranges matching
+        // if env var is set, use the requested version and bypass caching logic
+        let is_force_pin_version = env::var(self.env_var_version_name()).is_ok();
+        log::trace!("Command [{}] is_force_pin_version: {} - {:?}",
+            self.name(), is_force_pin_version, env::var(self.env_var_version_name()));
+
+        if !is_force_pin_version && !self.should_check_for_new_version().await {
+            log::trace!("Command [{}] NOT checking for the latest available version", &self.name());
+            return self.default_version().into();
+        }
+
+        let version =
+            env::var(self.env_var_version_name())
+                .unwrap_or_else(|_| self.default_version().into()).to_owned();
+
+        let latest = self.check_for_latest_version().await;
+
+        match latest {
+            Some(latest) => {
+                let norm_latest = self.normalize_version(latest.as_str());
+                let norm_version = self.normalize_version(&version);
+                if norm_latest.is_some() && norm_version.is_some() {
+                    // TODO use the VersionReq for semantic matching
+                    match norm_version.cmp(&norm_latest) {
+                        core::cmp::Ordering::Greater | core::cmp::Ordering::Equal => {
+                            log::debug!(
+                                            "Command [{}] requested version {} is already same or newer than available version {}",
+                                            self.name(), version, &latest)
+                        },
+                        core::cmp::Ordering::Less => {
+                            log::info!(
+                                            "Command [{}] requested version {}, but a newer version {} is available, you can try it out by \
+                                            setting the {}={} env var and re-running the command",
+                                            self.name(), version, &latest, self.env_var_version_name(), &latest)
+                        }
+                    }
+                }
+            }
+            None => log::warn!("Command [{}] failed to check for the latest version", self.name())
+        }
+
+        version
+    }
+
+    /// Attempts to convert a non-semver version string to a semver one.
+    /// E.g. WASM Opt uses `version_112`, which is not semver even if
+    /// we strip the prefix, treat it as `112.0.0`
+    fn normalize_version(&self, ver_string: &str) -> Option<Version> {
+        let ver_string = self.sanitize_version_prefix(ver_string);
+        match Version::parse(&ver_string) {
+            Ok(v) => Some(v),
+            Err(_) => {
+                match &ver_string.parse::<u64>() {
+                    Ok(num) => Some(Version::new(*num, 0, 0)),
+                    Err(_) => {
+                        match Version::parse(format!("{ver_string}.0").as_str()) {
+                            Ok(v) => Some(v),
+                            Err(e) => {
+                                log::error!("Command failed to normalize version {ver_string}: {e}");
+                                None
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Tailwind uses the 'vMaj.Min.Pat' format.
+    /// WASM opt uses 'version_NNN' format.
+    /// Cargo-generate has the 'vX.Y.Z' format
+    /// We generally want to keep the suffix intact,
+    /// as it carries classifiers, etc, but strip non-ascii
+    /// digits from the prefix.
+    #[inline]
+    fn sanitize_version_prefix(&self, ver_string: &str) -> String {
+        ver_string.chars().skip_while(|c| !c.is_ascii_digit() || *c == '_').collect::<String>()
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use cargo_metadata::semver::Version;
+    use super::*;
+
+    #[test]
+    fn test_sanitize_version_prefix() {
+        let command = CommandTailwind; // any will do
+        let version = command.sanitize_version_prefix("v1.2.3");
+        assert_eq!(version, "1.2.3");
+        assert!(Version::parse(&version).is_ok());
+        let version = command.sanitize_version_prefix("version_1.2.3");
+        assert_eq!(version, "1.2.3");
+        assert!(Version::parse(&version).is_ok());
+    }
+
+    #[test]
+    fn test_normalize_version() {
+        let command = CommandTailwind; // any will do
+        let version = command.normalize_version("version_112");
+        assert!(version.is_some_and(|v| {
+            v.major == 112 && v.minor == 0 && v.patch == 0
+        }));
+
+        let version = command.normalize_version("v3.3.3");
+        assert!(version.is_some_and(|v| {
+            v.major == 3 && v.minor == 3 && v.patch == 3
+        }));
+
+        let version = command.normalize_version("10.0.0");
+        assert!(version.is_some_and(|v| {
+            v.major == 10 && v.minor == 0 && v.patch == 0
+        }));
+    }
+
+    #[test]
+    fn test_incomplete_version_strings() {
+        let command = CommandTailwind; // any will do
+        let version = command.normalize_version("5");
+        assert!(version.is_some_and(|v| {
+            v.major == 5 && v.minor == 0 && v.patch == 0
+        }));
+
+        let version = command.normalize_version("0.2");
+        assert!(version.is_some_and(|v| {
+            v.major == 0 && v.minor == 2 && v.patch == 0
+        }));
+    }
+
+    #[test]
+    fn test_invalid_versions() {
+        let command = CommandTailwind; // any will do
+        let version = command.normalize_version("1a-test");
+        assert_eq!(version, None);
     }
 }

--- a/src/ext/tests.rs
+++ b/src/ext/tests.rs
@@ -6,8 +6,8 @@ use temp_dir::TempDir;
 #[tokio::test]
 async fn download_sass() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::Sass.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let meta = Exe::Sass.meta().await.unwrap();
+    let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
@@ -18,8 +18,8 @@ async fn download_sass() {
 #[tokio::test]
 async fn download_tailwind() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::Tailwind.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let meta = Exe::Tailwind.meta().await.unwrap();
+    let e = meta.with_cache_dir(dir.path()).await;
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
     let e = e.unwrap();
@@ -29,8 +29,8 @@ async fn download_tailwind() {
 #[tokio::test]
 async fn download_cargo_generate() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::CargoGenerate.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let meta = Exe::CargoGenerate.meta().await.unwrap();
+    let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 
@@ -41,8 +41,8 @@ async fn download_cargo_generate() {
 #[tokio::test]
 async fn download_wasmopt() {
     let dir = TempDir::new().unwrap();
-    let meta = Exe::WasmOpt.meta().unwrap();
-    let e = meta.with_cache_dir(&dir.path().to_path_buf()).await;
+    let meta = Exe::WasmOpt.meta().await.unwrap();
+    let e = meta.with_cache_dir(dir.path()).await;
 
     assert!(e.is_ok(), "{e:#?}\n{:#?}\nFiles: \n {}", meta, ls(&dir));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,5 +12,5 @@ async fn main() -> Result<()> {
     }
 
     let args = Cli::parse_from(&args);
-    crate::run(args).await
+    run(args).await
 }

--- a/src/service/reload.rs
+++ b/src/service/reload.rs
@@ -101,6 +101,7 @@ async fn websocket(mut stream: WebSocket) {
     });
 }
 
+#[allow(clippy::needless_pass_by_ref_mut)]
 async fn send(stream: &mut WebSocket, msg: BrowserMessage) {
     let site_addr = *SITE_ADDR.read().await;
     if !wait_for_socket("Reload", site_addr).await {


### PR DESCRIPTION
Reworked the command subsystem. Commands are now implemented as traits with default
template methods and just need to fill out the customized parts (vs duplicating most of the code).

Improved the user feedback, made the output consistent across commands.
Fixed error handling so any download and binary executable resolution problems are exposed (vs being silently swallowed).

## Some Highlights:
* `cargo leptos` will now check (once a day) for new versions of tools like `sass`,
`tailwindcss`, `wasm-ops` via the GitHub release API and inform the user of a newer available version. This happens lazily
for commands when they are used, but only once on startup and no more frequently than once a day.
* As part of the above exercise, improved the version recognition, so all kinds of variants like `1.0, version_112, v3.3.1, etc` are consistently handled and compared. This lays the foundation for the `semver` style version requests.
* As prompted by the command, a user can quickly try out the new version by overriding the env var, e.g. `LEPTOS_TAILWIND_VERSION=v3.3.3 cargo leptos watch --hot-reload -vv`. The binary will
be downloaded transparently and cached. Switching between tool versions has never been easier!
* Naturally, downgrades are now trivial as well (just pin the version via the env var).

### Added the following env vars:
```
LEPTOS_CARGO_GENERATE_VERSION
LEPTOS_TAILWIND_VERSION
LEPTOS_SASS_VERSION
LEPTOS_WASM_OPT_VERSION
```

## Things I'd Like to Do:
* Switch to the `semver` style [requests](https://docs.rs/semver/latest/semver/struct.VersionReq.html), so e.g. a patch-compatible version can be declared as desired and the updates are happening easily and transparently.
* Related to the above, remove the need for a hardcoded default version for every tool (do the best thing OOTB). Leveraging `semver` will ensure we pick up only compatible upgrades, unless instructed otherwise by the user.

#### P.S.: I'm not claiming to have extensive idiomatic Rust knowledge, feel free to propose all kinds of improvements to the code style.