### PR TITLE
Watch tailwind configuration and rebuild style on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ tailwind-input-file = "style/tailwind.css"
 
 # The tailwind config file.
 #
-# Optional, defaults to "./tailwind.config.js" which if is not present
+# Optional, defaults to "tailwind.config.js" which if is not present
 # is generated for you
-tailwind-config-file = "./tailwind.config.js"
+tailwind-config-file = "tailwind.config.js"
 
 # The browserlist https://browsersl.ist query used for optimizing the CSS.
 #

--- a/src/config/snapshots/cargo_leptos__config__tests__project.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__project.snap
@@ -52,7 +52,7 @@ Config {
                 tailwind: Some(
                     TailwindConfig {
                         input_file: "style/tailwind.css",
-                        config_file: "./tailwind.config.js",
+                        config_file: "tailwind.config.js",
                     },
                 ),
                 site_file: SiteFile {

--- a/src/config/tailwind.rs
+++ b/src/config/tailwind.rs
@@ -23,7 +23,7 @@ impl TailwindConfig {
         let config_file = conf.config_dir.join(
             conf.tailwind_config_file
                 .clone()
-                .unwrap_or_else(|| Utf8PathBuf::from("./tailwind.config.js")),
+                .unwrap_or_else(|| Utf8PathBuf::from("tailwind.config.js")),
         );
 
         Ok(Some(Self {


### PR DESCRIPTION
Changes to `tailwind.config.js` did not previously trigger a style rebuild (only `.rs` and `.css` files did). This watches the tailwind input and config paths specified in `Cargo.toml` and watches them for changes, rebuilding style as necessary.

Also adjusts defaults to avoid using a `./` relative path prefix as this breaks watch: https://github.com/leptos-rs/cargo-leptos/issues/99