### PR TITLE
Cleanup - addressed linter warnings:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ playwright/.cache/
 **/.env
 
 .DS_Store
+
+.idea/


### PR DESCRIPTION
* Drop redundant clone()
* Re-order impl methods to follow the trait order.