### PR TITLE
Remove stale clippy directive

### DIFF
--- a/src/service/reload.rs
+++ b/src/service/reload.rs
@@ -101,7 +101,6 @@ async fn websocket(mut stream: WebSocket) {
     });
 }
 
-#[allow(clippy::needless_pass_by_ref_mut)]
 async fn send(stream: &mut WebSocket, msg: BrowserMessage) {
     let site_addr = *SITE_ADDR.read().await;
     if !wait_for_socket("Reload", site_addr).await {


### PR DESCRIPTION
Running "cargo doc" gives this warning

warning: unknown lint: `clippy::needless_pass_by_ref_mut`
   --> src/service/reload.rs:104:9
    |
104 | #[allow(clippy::needless_pass_by_ref_mut)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::needless_pass_by_value`
    |
    = note: `#[warn(unknown_lints)]` on by default

warning: `cargo-leptos` (lib) generated 1 warning

The name "needless_pass_by_ref_mut" was not wrong at the time of writing, it is just stale

https://rust-lang.github.io/rust-clippy/master/index.html#/clippy::needless_pass_by_ref_mut

Additionally this "allow" is no longer needed to get cargo clippy to "pass" as of

cargo clippy --version
clippy 0.1.71 (8ede3aa 2023-07-12)