### PR TITLE
ran Cargo outdated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "chrono",
  "either",
  "getrandom",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "nom",
  "once_cell",
@@ -364,7 +364,7 @@ dependencies = [
  "flate2",
  "flexi_logger",
  "insta",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "leptos_hot_reload",
  "lightningcss",
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -708,18 +708,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
@@ -762,22 +762,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1324,6 +1325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,7 +1412,7 @@ dependencies = [
  "cssparser",
  "dashmap",
  "data-encoding",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "parcel_selectors",
  "parcel_sourcemap",
@@ -1692,6 +1702,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ axum = { version = "0.6", features = ["ws"] }
 # not using notify 5.0 because it uses Crossbeam which has an issue with tokio
 notify = "4.0"
 lazy_static = "1.4"
-which = "4.3"
-cargo_metadata = { version = "0.15", features = ["builder"] }
+which = "4.4"
+cargo_metadata = { version = "0.17", features = ["builder"] }
 serde_json = "1.0"
 wasm-bindgen-cli-support = "0.2"
 ansi_term = "0.12"
@@ -53,10 +53,10 @@ reqwest = { version = "0.11", features = [
   "native-tls-crate",
   "json",
 ], default-features = false }
-dirs = "4.0"
+dirs = "5.0"
 camino = "1.1"
 dotenvy = "0.15"
-itertools = "0.10"
+itertools = "0.11"
 derive_more = "0.99"
 flate2 = "1.0"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
@@ -68,7 +68,7 @@ semver = "1.0.18"
 async-trait = "0.1.72"
 
 [dev-dependencies]
-insta = { version = "1.23", features = ["yaml"] }
+insta = { version = "1.31.0", features = ["yaml"] }
 temp-dir = "0.1"
 
 [features]

--- a/src/service/reload.rs
+++ b/src/service/reload.rs
@@ -101,7 +101,6 @@ async fn websocket(mut stream: WebSocket) {
     });
 }
 
-#[allow(clippy::needless_pass_by_ref_mut)]
 async fn send(stream: &mut WebSocket, msg: BrowserMessage) {
     let site_addr = *SITE_ADDR.read().await;
     if !wait_for_socket("Reload", site_addr).await {


### PR DESCRIPTION
ran cargo outdated

I have trimmed down the list by using the modern versions of a couple of packges.

it a long list ... and can be completely cleared because of this

Cargo.toml
--  not using notify 5.0 because it uses Crossbeam which has an issue with tokio
notify = "4.0"