### PR TITLE
Dropped dependency on once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,6 @@ dependencies = [
  "lightningcss",
  "log",
  "notify",
- "once_cell",
  "reqwest",
  "seahash",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ categories = ["development-tools", "wasm", "web-programming"]
 keywords = ["leptos"]
 version = "0.1.11"
 edition = "2021"
+# OnceLock was stabailzed in 1.70
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -44,7 +46,7 @@ cargo_metadata = { version = "0.15", features = ["builder"] }
 serde_json = "1.0"
 wasm-bindgen-cli-support = "0.2"
 ansi_term = "0.12"
-once_cell = "1.16"
+
 seahash = "4.1"
 reqwest = { version = "0.11", features = [
   "blocking",

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,8 +3,8 @@ use flexi_logger::{
     filter::{LogLineFilter, LogLineWriter},
     DeferredNow, Level, Record,
 };
-use once_cell::sync::OnceCell;
 use std::io::Write;
+use std::sync::OnceLock;
 
 use crate::{config::Log, ext::StrAdditions};
 
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
 
    pub static ref GRAY: ansi_term::Color = Fixed(241);
    pub static ref BOLD: ansi_term::Style = Style::new().bold();
-   static ref LOG_SELECT: OnceCell<LogFlag> = OnceCell::new();
+   static ref LOG_SELECT: OnceLock<LogFlag> = OnceLock::new();
 }
 
 pub fn setup(verbose: u8, logs: &[Log]) {


### PR DESCRIPTION
In rust version 1.70.x "OnceCell" and it sync equivalent "OnceLock" were stabilized and moved in "std"

https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

From a maintenance perspective - One less package to track. From a security perspective - A reduced attack surface.

I have updated the Cargo.tomls "rust-version" to 1.70 to enforce this new reality.