### PR TITLE
Fix documentation for end-to-end command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Build tool for [Leptos](https://crates.io/crates/leptos):
 - `watch` command for automatic rebuilds with browser live-reload.
 - `test` command for running tests of the lib and bin packages that makes up the Leptos project.
 - `build` build the server and client.
-- `end2end` command for building, running the server and calling a bash shell hook. The hook would typically launch Playwright or similar.
+- `end-to-end` command for building, running the server and calling a bash shell hook. The hook would typically launch Playwright or similar.
 - `new` command for creating a new project based on templates, using [cargo-generate](https://cargo-generate.github.io/cargo-generate/index.html). Current templates include
   - [`https://github.com/leptos-rs/start`](https://github.com/leptos-rs/start): An Actix starter
   - [`https://github.com/leptos-rs/start-axum`](https://github.com/leptos-rs/start-axum): An Axum starter


### PR DESCRIPTION
It seems like the command was renamed at some point from `end2end` to `end-to-end`.