### PR TITLE
Option to watch additional files

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ js-dir = "src"
 # A change to any file in those directories will trigger a rebuild.
 #
 # Optional.
-additionnal-watch-files = ["additionnal_files", "custom_config.json"]
+watch-additionnal-files = ["additionnal_files", "custom_config.json"]
 
 # The IP and port where the server serves the content. Use it in your server setup.
 #

--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ assets-dir = "assets"
 # Optional. Defaults to "src"
 js-dir = "src"
 
-# Additionnal files your application could depends on.
+# Additional files your application could depends on.
 # A change to any file in those directories will trigger a rebuild.
 #
 # Optional.
-watch-additionnal-files = ["additionnal_files", "custom_config.json"]
+watch-additional-files = ["additional_files", "custom_config.json"]
 
 # The IP and port where the server serves the content. Use it in your server setup.
 #

--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ assets-dir = "assets"
 # Optional. Defaults to "src"
 js-dir = "src"
 
+# Additionnal files your application could depends on.
+# A change to any file in those directories will trigger a rebuild.
+#
+# Optional.
+additionnal-watch-files = ["additionnal_files", "custom_config.json"]
+
 # The IP and port where the server serves the content. Use it in your server setup.
 #
 # Optional, defaults to 127.0.0.1:3000. Env: LEPTOS_SITE_ADDR.

--- a/examples/project/Cargo.toml
+++ b/examples/project/Cargo.toml
@@ -86,8 +86,8 @@ assets-dir = "assets"
 # with `#[wasm_bindgen(module = "/js/foo.js")]`. A change in any JS file in this dir
 # will trigger a rebuild.
 js-dir = "js"
-# [Optional] Additionnal files to watch
-watch-additionnal-files = ["additionnal_files"]
+# [Optional] Additional files to watch
+watch-additional-files = ["additional_files"]
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
 site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring

--- a/examples/project/Cargo.toml
+++ b/examples/project/Cargo.toml
@@ -86,6 +86,8 @@ assets-dir = "assets"
 # with `#[wasm_bindgen(module = "/js/foo.js")]`. A change in any JS file in this dir
 # will trigger a rebuild.
 js-dir = "js"
+# [Optional] Additionnal files to watch
+watch-additionnal-files = ["additionnal_files"]
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
 site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring

--- a/examples/project/additionnal_files/foo.json
+++ b/examples/project/additionnal_files/foo.json
@@ -1,0 +1,3 @@
+{
+    "message": "Additionnal file"
+}

--- a/examples/project/additionnal_files/foo.json
+++ b/examples/project/additionnal_files/foo.json
@@ -1,3 +1,3 @@
 {
-    "message": "Additionnal file"
+  "message": "Additional file"
 }

--- a/src/compile/change.rs
+++ b/src/compile/change.rs
@@ -14,6 +14,8 @@ pub enum Change {
     Style,
     /// Cargo.toml changed
     Conf,
+    /// Additionnal file changed
+    Additionnal,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -39,11 +41,15 @@ impl ChangeSet {
     }
 
     pub fn need_server_build(&self) -> bool {
-        self.0.contains(&Change::BinSource) || self.0.contains(&Change::Conf)
+        self.0.contains(&Change::BinSource)
+            || self.0.contains(&Change::Conf)
+            || self.0.contains(&Change::Additionnal)
     }
 
     pub fn need_front_build(&self) -> bool {
-        self.0.contains(&Change::LibSource) || self.0.contains(&Change::Conf)
+        self.0.contains(&Change::LibSource)
+            || self.0.contains(&Change::Conf)
+            || self.0.contains(&Change::Additionnal)
     }
 
     pub fn asset_iter(&self) -> impl Iterator<Item = &Watched> {

--- a/src/compile/change.rs
+++ b/src/compile/change.rs
@@ -14,8 +14,8 @@ pub enum Change {
     Style,
     /// Cargo.toml changed
     Conf,
-    /// Additionnal file changed
-    Additionnal,
+    /// Additional file changed
+    Additional,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -43,13 +43,13 @@ impl ChangeSet {
     pub fn need_server_build(&self) -> bool {
         self.0.contains(&Change::BinSource)
             || self.0.contains(&Change::Conf)
-            || self.0.contains(&Change::Additionnal)
+            || self.0.contains(&Change::Additional)
     }
 
     pub fn need_front_build(&self) -> bool {
         self.0.contains(&Change::LibSource)
             || self.0.contains(&Change::Conf)
-            || self.0.contains(&Change::Additionnal)
+            || self.0.contains(&Change::Additional)
     }
 
     pub fn asset_iter(&self) -> impl Iterator<Item = &Watched> {

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -35,7 +35,7 @@ pub struct Project {
     pub end2end: Option<End2EndConfig>,
     pub assets: Option<AssetsConfig>,
     pub js_dir: Utf8PathBuf,
-    pub watch_additionnal_files: Vec<Utf8PathBuf>,
+    pub watch_additional_files: Vec<Utf8PathBuf>,
 }
 
 impl Debug for Project {
@@ -77,8 +77,7 @@ impl Project {
                 .clone()
                 .unwrap_or_else(|| Utf8PathBuf::from("src"));
 
-            let watch_additionnal_files =
-                config.watch_additionnal_files.clone().unwrap_or_default();
+            let watch_additional_files = config.watch_additional_files.clone().unwrap_or_default();
 
             let proj = Project {
                 working_dir: metadata.workspace_root.clone(),
@@ -93,7 +92,7 @@ impl Project {
                 end2end: End2EndConfig::resolve(&config),
                 assets: AssetsConfig::resolve(&config),
                 js_dir,
-                watch_additionnal_files,
+                watch_additional_files,
             };
             resolved.push(Arc::new(proj));
         }
@@ -147,7 +146,7 @@ pub struct ProjectConfig {
     /// js dir. changes triggers rebuilds.
     pub js_dir: Option<Utf8PathBuf>,
     /// additional files to watch. changes triggers rebuilds.
-    pub watch_additionnal_files: Option<Vec<Utf8PathBuf>>,
+    pub watch_additional_files: Option<Vec<Utf8PathBuf>>,
     #[serde(default = "default_reload_port")]
     pub reload_port: u16,
     /// command for launching end-2-end integration tests

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -35,6 +35,7 @@ pub struct Project {
     pub end2end: Option<End2EndConfig>,
     pub assets: Option<AssetsConfig>,
     pub js_dir: Utf8PathBuf,
+    pub watch_additionnal_files: Vec<Utf8PathBuf>,
 }
 
 impl Debug for Project {
@@ -76,6 +77,9 @@ impl Project {
                 .clone()
                 .unwrap_or_else(|| Utf8PathBuf::from("src"));
 
+            let watch_additionnal_files =
+                config.watch_additionnal_files.clone().unwrap_or_default();
+
             let proj = Project {
                 working_dir: metadata.workspace_root.clone(),
                 name: project.name.clone(),
@@ -89,6 +93,7 @@ impl Project {
                 end2end: End2EndConfig::resolve(&config),
                 assets: AssetsConfig::resolve(&config),
                 js_dir,
+                watch_additionnal_files,
             };
             resolved.push(Arc::new(proj));
         }
@@ -141,6 +146,8 @@ pub struct ProjectConfig {
     pub assets_dir: Option<Utf8PathBuf>,
     /// js dir. changes triggers rebuilds.
     pub js_dir: Option<Utf8PathBuf>,
+    /// additional files to watch. changes triggers rebuilds.
+    pub watch_additionnal_files: Option<Vec<Utf8PathBuf>>,
     #[serde(default = "default_reload_port")]
     pub reload_port: u16,
     /// command for launching end-2-end integration tests

--- a/src/service/notify.rs
+++ b/src/service/notify.rs
@@ -20,7 +20,7 @@ pub async fn spawn(proj: &Arc<Project>) -> Result<JoinHandle<()>> {
 
     set.extend(proj.lib.src_paths.clone());
     set.extend(proj.bin.src_paths.clone());
-    set.extend(proj.watch_additionnal_files.clone());
+    set.extend(proj.watch_additional_files.clone());
     set.insert(proj.js_dir.clone());
 
     if let Some(file) = &proj.style.file {
@@ -132,12 +132,12 @@ fn handle(watched: Watched, proj: Arc<Project>) {
         }
     }
 
-    if path.starts_with_any(&proj.watch_additionnal_files) {
+    if path.starts_with_any(&proj.watch_additional_files) {
         log::debug!(
-            "Notify additionnal file change {}",
+            "Notify additional file change {}",
             GRAY.paint(watched.to_string())
         );
-        changes.push(Change::Additionnal);
+        changes.push(Change::Additional);
     }
 
     if !changes.is_empty() {


### PR DESCRIPTION
Add an option to watch any file:

```toml
# Additional files your application could depends on.
# A change to any file in those directories will trigger a rebuild.
#
# Optional.
watch-additional-files = ["additional_files", "custom_config.json"]
```

A change to any of those files trigger a rebuild of both client and server.