### PR TITLE
Specify browser targets in minify step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,19 +617,24 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
+checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "matches",
  "phf",
- "proc-macro2",
- "quote",
  "smallvec",
- "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser-color"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
+dependencies = [
+ "cssparser",
 ]
 
 [[package]]
@@ -1400,15 +1405,16 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.45"
+version = "1.0.0-alpha.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f87dd0377974affb751fedb4d394b0fce51829227ec6afe4fa7d51eeb6383b"
+checksum = "6b9e0bcd2b6bb94c671476ae1d4cba1d5da256394ae18e3f656d2d339d577b5a"
 dependencies = [
  "ahash 0.7.6",
  "bitflags 2.4.0",
  "browserslist-rs",
  "const-str",
  "cssparser",
+ "cssparser-color",
  "dashmap",
  "data-encoding",
  "itertools 0.10.5",
@@ -1716,9 +1722,9 @@ checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "parcel_selectors"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1aa68e6c4bf7a49302b9c711c880c1cc2a7dc5c5184042cc724e4124e0d95f"
+checksum = "5f0fbe4365a6ec3fda13f9551aa5ea9f1e1ee8da513953b153de29ac00cf684a"
 dependencies = [
  "bitflags 2.4.0",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 log = "0.4"
 flexi_logger = "0.25"
-lightningcss = { version = "1.0.0-alpha.42", features = ["browserslist"] }
+lightningcss = { version = "1.0.0-alpha.47", features = ["browserslist"] }
 tokio = { version = "1.4", default-features = false, features = ["full"] }
 axum = { version = "0.6", features = ["ws"] }
 # not using notify 5.0 because it uses Crossbeam which has an issue with tokio

--- a/src/compile/style.rs
+++ b/src/compile/style.rs
@@ -91,16 +91,21 @@ fn browser_lists(query: &str) -> Result<Option<Browsers>> {
 
 async fn process_css(proj: &Project, css: String) -> Result<Product> {
     let browsers = browser_lists(&proj.style.browserquery).context("leptos.style.browserquery")?;
+    let targets = Targets::from(browsers);
 
     let mut stylesheet =
         StyleSheet::parse(&css, ParserOptions::default()).map_err(|e| anyhow!("{e}"))?;
 
     if proj.release {
-        stylesheet.minify(MinifyOptions::default())?;
+        let minify_options = MinifyOptions {
+            targets,
+            ..Default::default()
+        };
+        stylesheet.minify(minify_options)?;
     }
 
     let options = PrinterOptions::<'_> {
-        targets: Targets::from(browsers),
+        targets,
         minify: proj.release,
         ..Default::default()
     };


### PR DESCRIPTION
Use target browsers in minify step.

A few months ago I ran into an issue, when compiling in release mode, where some css rules were wrongly merging together, resulting in broken css in firefox. I thought the issue was in lightningcss and [reported it there at the time](
https://github.com/parcel-bundler/lightningcss/issues/548), and now it seems the issue has been fixed on that side.

However I tested with latest lightningcss and the issue persisted, so it seemed like the only way this was happening was if the targets weren't being correctly passed in the minify step and lo and behold that was indeed what was happening. I also tried only the code change without bumping lightningcss and that was not enough to generate correct css.

With both passing targets and bumping lightningcss, the css generated correctly.