### PR TITLE
Fix tailwind with plugins by using a temporary file

### DIFF
--- a/src/compile/tailwind.rs
+++ b/src/compile/tailwind.rs
@@ -34,7 +34,13 @@ pub async fn compile_tailwind(
 
             if done {
                 log::info!("Tailwind finished {}", GRAY.paint(line));
-                Ok(Outcome::Success(output.stdout()))
+                match fs::read_to_string(&tw_conf.tmp_file).await {
+                    Ok(content) => Ok(Outcome::Success(content)),
+                    Err(e) => {
+                        log::error!("Failed to read tailwind result: {e}");
+                        Ok(Outcome::Failed)
+                    }
+                }
             } else {
                 log::warn!("Tailwind failed {}", GRAY.paint(line));
                 println!("{}\n{}", output.stdout(), output.stderr());
@@ -77,6 +83,8 @@ pub async fn tailwind_process(cmd: &str, tw_conf: &TailwindConfig) -> Result<(St
         tw_conf.input_file.as_str(),
         "--config",
         tw_conf.config_file.as_str(),
+        "--output",
+        tw_conf.tmp_file.as_str(),
     ];
     let line = format!("{} {}", cmd, args.join(" "));
     let mut command = Command::new(tailwind);

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -185,6 +185,8 @@ pub struct ProjectConfig {
 
     #[serde(skip)]
     pub config_dir: Utf8PathBuf,
+    #[serde(skip)]
+    pub tmp_dir: Utf8PathBuf,
 
     // Profiles
     pub lib_profile_dev: Option<String>,
@@ -197,6 +199,7 @@ impl ProjectConfig {
     fn parse(dir: &Utf8Path, metadata: &serde_json::Value, cargo_metadata: &Metadata) -> Result<Self> {
         let mut conf: ProjectConfig = serde_json::from_value(metadata.clone())?;
         conf.config_dir = dir.to_path_buf();
+        conf.tmp_dir = cargo_metadata.target_directory.join("tmp");
         let dotenvs = load_dotenvs(dir)?;
         overlay_env(&mut conf, dotenvs)?;
         if conf.site_root == "/"

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -199,7 +199,7 @@ impl ProjectConfig {
     fn parse(dir: &Utf8Path, metadata: &serde_json::Value, cargo_metadata: &Metadata) -> Result<Self> {
         let mut conf: ProjectConfig = serde_json::from_value(metadata.clone())?;
         conf.config_dir = dir.to_path_buf();
-        conf.tmp_dir = cargo_metadata.target_directory.join("tmp");
+        conf.tmp_dir = cargo_metadata.target_directory.join("tmp").unbase(&cargo_metadata.workspace_root).unwrap();
         let dotenvs = load_dotenvs(dir)?;
         overlay_env(&mut conf, dotenvs)?;
         if conf.site_root == "/"

--- a/src/config/snapshots/cargo_leptos__config__tests__project.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__project.snap
@@ -53,6 +53,7 @@ Config {
                     TailwindConfig {
                         input_file: "style/tailwind.css",
                         config_file: "tailwind.config.js",
+                        tmp_file: "target/tmp/tailwind.css",
                     },
                 ),
                 site_file: SiteFile {

--- a/src/config/tailwind.rs
+++ b/src/config/tailwind.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Result};
 pub struct TailwindConfig {
     pub input_file: Utf8PathBuf,
     pub config_file: Utf8PathBuf,
+    pub tmp_file: Utf8PathBuf,
 }
 
 impl TailwindConfig {
@@ -26,9 +27,12 @@ impl TailwindConfig {
                 .unwrap_or_else(|| Utf8PathBuf::from("tailwind.config.js")),
         );
 
+        let tmp_file = conf.tmp_dir.join("tailwind.css");
+
         Ok(Some(Self {
             input_file,
             config_file,
+            tmp_file,
         }))
     }
 }


### PR DESCRIPTION
closes #136 

Let tailwind output to a temporary file and read it afterwards instead of returning the stdout of the tailwind command.

I didn't know a better way than to put the temp file into a `tmp` directory inside the `target` folder.
`temp_dir` isn't supported by serde and I didn't want to put it into the `TailwindConfig` struct.

The path is present in the output for the output of the tailwind command for better transparency with the users.