### PR TITLE
Fix incremental compilation by using separate target dir for front

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ lib-profile-release = "my-release-profile"
 #
 # Optional. Defaults to "debug".
 lib-profile-dev = "my-debug-profile"
+
+# Fixes cargo bug that prevents incremental compilation (see #203)
+#
+# Optional. Defaults to false
+separate-front-target-dir = true
 ```
 
 ## Site parameters

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -68,6 +68,11 @@ pub fn build_cargo_front_cmd(
         format!("--package={}", proj.lib.name.as_str()),
         "--lib".to_string(),
     ];
+
+    if let Some(path) = &proj.lib.front_target_path {
+        args.push(format!("--target-dir={path}"))
+    }
+
     if wasm {
         args.push("--target=wasm32-unknown-unknown".to_string());
     }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -186,6 +186,9 @@ pub struct ProjectConfig {
     #[serde(skip)]
     pub config_dir: Utf8PathBuf,
 
+    #[serde(default)]
+    pub separate_front_target_dir: bool,
+
     // Profiles
     pub lib_profile_dev: Option<String>,
     pub lib_profile_release: Option<String>,


### PR DESCRIPTION
`cargo leptos watch` compiles frontend and server code completely new, without using incremental compilation.

This is a bug of `cargo` or `rustc`, because changing the target from `native` to `wasm32` changes the `RUSTFLAGS` which in turn triggers a complete rebuild by cargo (see https://github.com/rust-lang/cargo/issues/8716).

This PR introduces a new option in the project settings (`separate-front-target-dir`) that instructs `cargo leptos` to change the `--target-dir` for the frontend compilation to `<project-taget-dir>/front` so that the `RUSTFLAGS` stay the same between the compilations.