### PR TITLE
Add --bin-skip flag to build command

### DIFF
--- a/src/command/end2end.rs
+++ b/src/command/end2end.rs
@@ -18,7 +18,7 @@ pub async fn end2end_all(conf: &Config) -> Result<()> {
 
 pub async fn end2end_proj(proj: &Arc<Project>) -> Result<()> {
     if let Some(e2e) = &proj.end2end {
-        if !super::build::build_proj(proj).await.dot()? {
+        if !super::build::build_proj(proj, false).await.dot()? {
             return Ok(());
         }
 

--- a/src/command/serve.rs
+++ b/src/command/serve.rs
@@ -5,7 +5,7 @@ use crate::ext::anyhow::{Context, Result};
 use crate::service::serve;
 
 pub async fn serve(proj: &Arc<Project>) -> Result<()> {
-    if !super::build::build_proj(proj).await.dot()? {
+    if !super::build::build_proj(proj, false).await.dot()? {
         return Ok(());
     }
     let server = serve::spawn_oneshot(proj).await;

--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -15,7 +15,7 @@ use super::build::build_proj;
 
 pub async fn watch(proj: &Arc<Project>) -> Result<()> {
     // even if the build fails, we continue
-    build_proj(proj).await?;
+    build_proj(proj, false).await?;
 
     // but if ctrl-c is pressed, we stop
     if Interrupt::is_shutdown_requested().await {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,7 +14,7 @@ mod tailwind;
 
 use std::{fmt::Debug, sync::Arc};
 
-pub use self::cli::{Cli, Commands, Log, Opts};
+pub use self::cli::{BuildOpts, Cli, Commands, Log, Opts};
 use crate::ext::{
     anyhow::{Context, Result},
     MetadataExt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod logger;
 pub mod service;
 pub mod signal;
 
-use crate::config::Commands;
+use crate::config::{BuildOpts, Commands};
 use crate::ext::anyhow::{Context, Result};
 use crate::ext::PathBufExt;
 use crate::logger::GRAY;
@@ -72,7 +72,7 @@ pub async fn run(args: Cli) -> Result<()> {
     use Commands::{Build, EndToEnd, New, Serve, Test, Watch};
     match args.command {
         New(_) => panic!(),
-        Build(_) => command::build_all(&config).await,
+        Build(BuildOpts { bin_skip, .. }) => command::build_all(&config, bin_skip).await,
         Serve(_) => command::serve(&config.current_project()?).await,
         Test(_) => command::test_all(&config).await,
         EndToEnd(_) => command::end2end_all(&config).await,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,14 +1,14 @@
 use camino::Utf8PathBuf;
 
 use crate::{
-    config::{Cli, Commands, Opts},
+    config::{BuildOpts, Cli, Commands},
     ext::PathBufExt,
     run,
 };
 
 #[tokio::test]
 async fn workspace_build() {
-    let command = Commands::Build(Opts::default());
+    let command = Commands::Build(BuildOpts::default());
 
     let cli = Cli {
         manifest_path: Some(Utf8PathBuf::from("examples/workspace/Cargo.toml")),


### PR DESCRIPTION
## Utility

In certain pipelines, it is convenient to use `cargo-leptos` to build the lib target and associated files only. This can be done currently by re-implementing the functionality `cargo-leptos` provides manually, but that may require parsing the project's `Cargo.toml`, and it certainly requires more knowledge of the build process than is otherwise required to successfully use `cargo-leptos`.

An example where this is especially useful is a deploy pipeline for an AWS Lambda function. The server binary destined for the function must, among other things, target a particular architecture. [`cargo-lambda`](https://github.com/cargo-lambda/cargo-lambda) makes this very easy to achieve. Of course, the lib target and associated files do not require anything different, so they can be built with `cargo-leptos` as normal. Here's what this might look like currently:

```
cargo leptos build --release
cargo lambda build --no-default-features --features=ssr --release
cargo lambda deploy --include target/site --enable-function-url
```

In this sequence, the bin target is built twice. With a `--bin-skip` flag, it would only be built once:

```
cargo leptos build --release --bin-skip
cargo lambda build --no-default-features --features=ssr --release
cargo lambda deploy --include target/site --enable-function-url
```

## Implementation

My implementation is rather quick and dirty. I wanted to avoid adding a flag to all the subcommands when it only makes sense for `build`. Duplicating a large struct only to change one member is not ideal though. If there's a better approach for this feature, I'm all ears! I also totally understand if this feature isn't all that appropriate at the end of the day.

It may also make more sense to provide mutually exclusive flags (or an option of some sort) so either target can be skipped.