### PR TITLE
Cargo.lock needs updating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-leptos"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ansi_term",
  "anyhow",


### PR DESCRIPTION
Nix cares if the Cargo.lock is out of date, it needs to be updated when a new release goes out