### PR TITLE
Fix passing multiple cargo args via `--{bin,lib}-cargo-args`

### DIFF
--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -84,9 +84,7 @@ pub fn build_cargo_front_cmd(
 
     // Add cargo flags to cargo command
     if let Some(cargo_args) = &proj.lib.cargo_args {
-        if !cargo_args.is_empty() {
-            args.push(format!("{}", cargo_args.join(" ")))
-        }
+        args.extend_from_slice(cargo_args);
     }
 
     proj.lib.profile.add_to_args(&mut args);

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -98,7 +98,7 @@ pub fn build_cargo_front_cmd(
         .join(" ");
 
     command.args(&args).envs(envs);
-    let line = format!("cargo {}", args.join(" "));
+    let line = super::build_cargo_command_string(args);
     (envs_str, line)
 }
 

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -17,7 +17,7 @@ pub use style::style;
 
 use itertools::Itertools;
 
-fn build_cargo_command_string(args: Vec<String>) -> String {
+fn build_cargo_command_string(args: impl IntoIterator<Item = String>) -> String {
     std::iter::once("cargo".to_owned())
         .chain(args.into_iter().map(|arg| {
             if arg.contains(' ') {

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -14,3 +14,17 @@ pub use change::{Change, ChangeSet};
 pub use front::{front, front_cargo_process};
 pub use server::{server, server_cargo_process};
 pub use style::style;
+
+use itertools::Itertools;
+
+fn build_cargo_command_string(args: Vec<String>) -> String {
+    std::iter::once("cargo".to_owned())
+        .chain(args.into_iter().map(|arg| {
+            if arg.contains(' ') {
+                format!("'{arg}'")
+            } else {
+                arg
+            }
+        }))
+        .join(" ")
+}

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -87,9 +87,7 @@ pub fn build_cargo_server_cmd(
     log::debug!("BIN CARGO ARGS: {:?}", &proj.bin.cargo_args);
     // Add cargo flags to cargo command
     if let Some(cargo_args) = &proj.bin.cargo_args {
-        if !cargo_args.is_empty() {
-            args.push(format!("{}", cargo_args.join(" ")))
-        }
+        args.extend_from_slice(cargo_args);
     }
     proj.bin.profile.add_to_args(&mut args);
 

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -100,6 +100,6 @@ pub fn build_cargo_server_cmd(
         .join(" ");
 
     command.args(&args).envs(envs);
-    let line = format!("cargo {}", args.join(" "));
+    let line = super::build_cargo_command_string(args);
     (envs_str, line)
 }

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -136,3 +136,23 @@ fn test_workspace_project2() {
 
     assert_display_snapshot!(cargo, @"cargo build --package=project2 --lib --target-dir=/celPool/celData/Works/projects/cargo-leptos/examples/workspace/target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate");
 }
+
+#[test]
+fn test_extra_cargo_args() {
+    let cli = Opts {
+        lib_cargo_args: Some(vec!["-j".into(), "8".into()]),
+        bin_cargo_args: Some(vec!["-j".into(), "16".into()]),
+        ..dev_opts()
+    };
+    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true);
+
+    let mut command = Command::new("cargo");
+    let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
+
+    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr -j 16");
+
+    let mut command = Command::new("cargo");
+    let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
+
+    assert_display_snapshot!(cargo, @"cargo build --package=example --lib --target-dir=/celPool/celData/Works/projects/cargo-leptos/examples/project/target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate -j 8");
+}


### PR DESCRIPTION
This PR fixes passing multiple cargo args via `--bin-cargo-args` and
`--lib-cargo-args`. Previously those arguments would be merged into a
single argument containing spaces inside, leading to errors.

Discovered when trying to cross-compile in a wrong way (before figuring
out `LEPTOS_BIN_TARGET_TRIPLE`) and getting this error:

```
error: unexpected argument '--target x86_64-unknown-linux-gnu' found

  tip: a similar argument exists: '--target'
```
