### PR TITLE
Add `cargo-insta` to dev shell in Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             openssl
             pkg-config
             cargo-dist
+            cargo-insta
             llvmPackages_latest.llvm
             llvmPackages_latest.bintools
             zlib.out


### PR DESCRIPTION
Since `insta` is used for snapshots in tests, it is convenient to have
`cargo-insta` in PATH.
