### PR TITLE
Add `.direnv/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ playwright/.cache/
 .DS_Store
 
 .idea/
+
+.direnv/


### PR DESCRIPTION
Add `.direnv` directory created by [`nix-direnv`](https://github.com/nix-community/nix-direnv) to `.gitignore`, since both direnv and nix are used in the project.
