### PR TITLE
Doc `bin-cargo-command` in `README.me`

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ lib-cargo-args = ["--timings"]
 # 
 # Optional. No default
 bin-cargo-args = ["--timings"]
+
+# The command to run instead of "cargo" when building the server
+#
+# Optional. No default. Env: LEPTOS_BIN_CARGO_COMMAND
+bin-cargo-command = "cross"
 ```
 
 ## Site parameters

--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ separate-front-target-dir = true
 # Pass additional parameters to the cargo process compiling to WASM
 # 
 # Optional. No default
-lib_cargo-args = ["--timings"]
+lib-cargo-args = ["--timings"]
 
 # Pass additional parameters to the cargo process to build the server
 # 
 # Optional. No default
-bin_cargo-args = ["--timings"]
+bin-cargo-args = ["--timings"]
 ```
 
 ## Site parameters


### PR DESCRIPTION
As discussed in #224 (better late than never I hope), `bin-cargo-command` is now included in the readme.

Secondly, I noticed two other lines were mixed between snake and kebab-case. Went ahead and corrected those.