### PR TITLE
Add more debug logs.

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -15,6 +15,7 @@ pub async fn build_all(conf: &Config) -> Result<()> {
     let mut first_failed_project = None;
 
     for proj in &conf.projects {
+        log::debug!("Building project: {}, {}", proj.name, proj.working_dir);
         if !build_proj(proj).await? && first_failed_project.is_none() {
             first_failed_project = Some(proj);
         }

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -35,6 +35,7 @@ pub async fn front(
 
         let (envs, line, process) = front_cargo_process("build", true, &proj)?;
 
+        log::debug!("Running {}", GRAY.paint(&line));
         match wait_interruptible("Cargo", process, Interrupt::subscribe_any()).await? {
             CommandResult::Interrupted => return Ok(Outcome::Stopped),
             CommandResult::Failure(_) => return Ok(Outcome::Failed),


### PR DESCRIPTION
This really helped me debug my issue.

Otherwise, if there's an error, the `match` on the next line returns w/o telling me the command that was run to cause the error.