### PR TITLE
bin_exe override

### DIFF
--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -98,7 +98,7 @@ impl BinPackage {
             if let Some(triple) = &config.bin_target_triple {
                 file = file.join(triple)
             };
-            let name = if let Some(name) = &config.bin_exe {
+            let name = if let Some(name) = &config.bin_exe_name {
                 name
             } else {
                 &name

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -98,8 +98,13 @@ impl BinPackage {
             if let Some(triple) = &config.bin_target_triple {
                 file = file.join(triple)
             };
+            let name = if let Some(name) = &config.bin_exe {
+                name
+            } else {
+                &name
+            };
             file.join(profile.to_string())
-                .join(&name)
+                .join(name)
                 .with_extension(file_ext)
         };
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -174,6 +174,8 @@ pub struct ProjectConfig {
     pub bin_cargo_command: Option<String>,
     /// cargo flags to pass to cargo when running the server. Overriden by bin_cargo_command
     pub bin_cargo_args: Option<String>,
+    /// An optional override, if you've changed the name of your bin file in your project use this to override the default to the new name.
+    pub bin_exe: Option<String>,
     #[serde(default)]
     pub features: Vec<String>,
     #[serde(default)]

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -174,8 +174,8 @@ pub struct ProjectConfig {
     pub bin_cargo_command: Option<String>,
     /// cargo flags to pass to cargo when running the server. Overriden by bin_cargo_command
     pub bin_cargo_args: Option<String>,
-    /// An optional override, if you've changed the name of your bin file in your project use this to override the default to the new name.
-    pub bin_exe: Option<String>,
+    /// An optional override, if you've changed the name of your bin file in your project you'll need to set it here as well.
+    pub bin_exe_name: Option<String>,
     #[serde(default)]
     pub features: Vec<String>,
     #[serde(default)]


### PR DESCRIPTION
If your bin name is different then your package name you'll get a missing file error.
```rust
Error: at `/Users/sam/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.2.5/src/command/serve.rs:8:46`

Caused by:
    0: at `/Users/sam/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.2.5/src/compile/server.rs:39:22`
    1: at `/Users/sam/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.2.5/src/service/site.rs:117:44`
    2: Could not read "target/debug/leptos_chat_app" at `/Users/sam/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.2.5/src/ext/fs.rs:44:10`
    3: No such file or directory (os error 2)
 ```
 But this pull request adds a bin-exe parameter which you can use to change the output file name.