### PR TITLE
Add bin args for `watch` and `serve` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-leptos"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -39,7 +39,7 @@ fn dev_opts() -> Opts {
 #[test]
 fn test_project_dev() {
     let cli = dev_opts();
-    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true, None);
 
     let mut command = Command::new("cargo");
     let (envs, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
@@ -70,7 +70,7 @@ fn test_project_dev() {
 #[test]
 fn test_project_release() {
     let cli = release_opts();
-    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true, None);
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
@@ -112,7 +112,7 @@ fn test_workspace_project1() {
     };
 
     let cli = dev_opts();
-    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true, None);
 
     let mut command = Command::new("cargo");
     let (envs, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
@@ -134,7 +134,7 @@ fn test_workspace_project1() {
 #[test]
 fn test_workspace_project2() {
     let cli = dev_opts();
-    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true, None);
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[1], &mut command);
@@ -158,7 +158,7 @@ fn test_extra_cargo_args() {
         bin_cargo_args: Some(vec!["-j".into(), "16".into()]),
         ..dev_opts()
     };
-    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/project/Cargo.toml", true, None);
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -26,6 +26,7 @@ pub struct BinPackage {
     pub target_dir: Option<String>,
     pub cargo_command: Option<String>,
     pub cargo_args: Option<Vec<String>>,
+    pub bin_args: Option<Vec<String>>,
 }
 
 impl BinPackage {
@@ -34,6 +35,7 @@ impl BinPackage {
         metadata: &Metadata,
         project: &ProjectDefinition,
         config: &ProjectConfig,
+        bin_args: Option<&[String]>,
     ) -> Result<Self> {
         let mut features = if !cli.bin_features.is_empty() {
             cli.bin_features.clone()
@@ -128,6 +130,7 @@ impl BinPackage {
             target_dir: config.bin_target_dir.clone(),
             cargo_command: config.bin_cargo_command.clone(),
             cargo_args: cli.bin_cargo_args.clone(),
+            bin_args: bin_args.map(ToOwned::to_owned),
         })
     }
 }
@@ -151,6 +154,7 @@ impl std::fmt::Debug for BinPackage {
                     .join(", "),
             )
             .field("profile", &self.profile)
+            .field("bin_args", &self.bin_args)
             .finish_non_exhaustive()
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,10 +46,16 @@ impl Debug for Config {
 }
 
 impl Config {
-    pub fn load(cli: Opts, cwd: &Utf8Path, manifest_path: &Utf8Path, watch: bool) -> Result<Self> {
+    pub fn load(
+        cli: Opts,
+        cwd: &Utf8Path,
+        manifest_path: &Utf8Path,
+        watch: bool,
+        bin_args: Option<&[String]>,
+    ) -> Result<Self> {
         let metadata = Metadata::load_cleaned(manifest_path)?;
 
-        let mut projects = Project::resolve(&cli, cwd, &metadata, watch).dot()?;
+        let mut projects = Project::resolve(&cli, cwd, &metadata, watch, bin_args).dot()?;
 
         if projects.is_empty() {
             bail!("Please define leptos projects in the workspace Cargo.toml sections [[workspace.metadata.leptos]]")
@@ -75,7 +81,13 @@ impl Config {
     }
 
     #[cfg(test)]
-    pub fn test_load(cli: Opts, cwd: &str, manifest_path: &str, watch: bool) -> Self {
+    pub fn test_load(
+        cli: Opts,
+        cwd: &str,
+        manifest_path: &str,
+        watch: bool,
+        bin_args: Option<&[String]>,
+    ) -> Self {
         use crate::ext::PathBufExt;
 
         let manifest_path = Utf8PathBuf::from(manifest_path)
@@ -83,7 +95,7 @@ impl Config {
             .unwrap();
         let mut cwd = Utf8PathBuf::from(cwd).canonicalize_utf8().unwrap();
         cwd.clean_windows_path();
-        Self::load(cli, &cwd, &manifest_path, watch).unwrap()
+        Self::load(cli, &cwd, &manifest_path, watch, bin_args).unwrap()
     }
 
     pub fn current_project(&self) -> Result<Arc<Project>> {

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -68,6 +68,7 @@ impl Project {
         cwd: &Utf8Path,
         metadata: &Metadata,
         watch: bool,
+        bin_args: Option<&[String]>,
     ) -> Result<Vec<Arc<Project>>> {
         let projects = ProjectDefinition::parse(metadata)?;
 
@@ -90,7 +91,7 @@ impl Project {
                 working_dir: metadata.workspace_root.clone(),
                 name: project.name.clone(),
                 lib,
-                bin: BinPackage::resolve(cli, metadata, &project, &config)?,
+                bin: BinPackage::resolve(cli, metadata, &project, &config, bin_args)?,
                 style: StyleConfig::new(&config)?,
                 watch,
                 release: cli.release,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -34,6 +34,7 @@ Config {
                 default_features: false,
                 src_paths: "project1/app/src, project1/server/src",
                 profile: Debug,
+                bin_args: None,
                 ..
             },
             style: StyleConfig {
@@ -105,6 +106,7 @@ Config {
                 default_features: false,
                 src_paths: "project2/src",
                 profile: Debug,
+                bin_args: None,
                 ..
             },
             style: StyleConfig {

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -5,51 +5,60 @@ expression: conf
 Config {
     projects: [
         Project {
-            name: "project1",
+            name: "project2",
             lib: LibPackage {
-                name: "front-package",
-                rel_dir: "project1/front",
+                name: "project2",
+                rel_dir: "project2",
                 wasm_file: SourcedSiteFile {
-                    source: "target/front/wasm32-unknown-unknown/debug/front_package.wasm",
-                    dest: "target/site/project1/pkg/project1.wasm",
-                    site: "pkg/project1.wasm",
+                    source: "target/front/wasm32-unknown-unknown/debug/project2.wasm",
+                    dest: "target/site/project2/pkg/project2.wasm",
+                    site: "pkg/project2.wasm",
                 },
                 js_file: SiteFile {
-                    dest: "target/site/project1/pkg/project1.js",
-                    site: "pkg/project1.js",
+                    dest: "target/site/project2/pkg/project2.js",
+                    site: "pkg/project2.js",
                 },
-                features: [],
+                features: [
+                    "hydrate",
+                ],
                 default_features: false,
-                output_name: "project1",
-                src_paths: "project1/app/src, project1/front/src",
+                output_name: "project2",
+                src_paths: "project2/src",
                 profile: Debug,
                 ..
             },
             bin: BinPackage {
-                name: "server-package",
-                rel_dir: "project1/server",
-                exe_file: "target/debug/server-package",
-                target: "server-package",
-                features: [],
+                name: "project2",
+                rel_dir: "project2",
+                exe_file: "target/debug/project2",
+                target: "project2",
+                features: [
+                    "ssr",
+                ],
                 default_features: false,
-                src_paths: "project1/app/src, project1/server/src",
+                src_paths: "project2/src",
                 profile: Debug,
-                bin_args: None,
+                bin_args: Some(
+                    [
+                        "--",
+                        "--foo",
+                    ],
+                ),
                 ..
             },
             style: StyleConfig {
                 file: Some(
                     SourcedSiteFile {
-                        source: "project1/css/main.scss",
-                        dest: "target/site/project1/pkg/project1.css",
-                        site: "pkg/project1.css",
+                        source: "project2/src/main.scss",
+                        dest: "target/site/project2/pkg/project2.css",
+                        site: "pkg/project2.css",
                     },
                 ),
                 browserquery: "defaults",
                 tailwind: None,
                 site_file: SiteFile {
-                    dest: "target/site/project1/pkg/project1.css",
-                    site: "pkg/project1.css",
+                    dest: "target/site/project2/pkg/project2.css",
+                    site: "pkg/project2.css",
                 },
             },
             watch: true,
@@ -59,7 +68,7 @@ Config {
             site: Site {
                 addr: 127.0.0.1:3000,
                 reload: 127.0.0.1:3001,
-                root_dir: "target/site/project1",
+                root_dir: "target/site/project2",
                 pkg_dir: "pkg",
                 file_reg: {},
                 ext_file_reg: {},
@@ -67,7 +76,7 @@ Config {
             end2end: None,
             assets: Some(
                 AssetsConfig {
-                    dir: "project1/assets",
+                    dir: "project2/src/assets",
                 },
             ),
             ..
@@ -78,7 +87,7 @@ Config {
         precompress: false,
         hot_reload: false,
         project: Some(
-            "project1",
+            "project2",
         ),
         features: [],
         lib_features: [],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -38,6 +38,7 @@ Config {
                 default_features: false,
                 src_paths: "project2/src",
                 profile: Debug,
+                bin_args: None,
                 ..
             },
             style: StyleConfig {

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -38,6 +38,7 @@ Config {
                 default_features: false,
                 src_paths: "project2/src",
                 profile: Debug,
+                bin_args: None,
                 ..
             },
             style: StyleConfig {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -30,7 +30,7 @@ fn test_project() {
 fn test_workspace() {
     let cli = opts(None);
 
-    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true, None);
 
     insta::assert_debug_snapshot!(conf);
 }
@@ -39,7 +39,7 @@ fn test_workspace() {
 fn test_workspace_project1() {
     let cli = opts(Some("project1"));
 
-    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true, None);
 
     insta::assert_debug_snapshot!(conf);
 }
@@ -48,7 +48,7 @@ fn test_workspace_project1() {
 fn test_workspace_project2() {
     let cli = opts(Some("project2"));
 
-    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true);
+    let conf = Config::test_load(cli, "examples", "examples/workspace/Cargo.toml", true, None);
 
     insta::assert_debug_snapshot!(conf);
 }
@@ -62,6 +62,22 @@ fn test_workspace_in_subdir_project2() {
         "examples/workspace/project2",
         "examples/workspace/Cargo.toml",
         true,
+        None,
+    );
+
+    insta::assert_debug_snapshot!(conf);
+}
+
+#[test]
+fn test_workspace_bin_args_project2() {
+    let cli = opts(Some("project2"));
+
+    let conf = Config::test_load(
+        cli,
+        "examples",
+        "examples/workspace/Cargo.toml",
+        true,
+        Some(&["--".to_string(), "--foo".to_string()]),
     );
 
     insta::assert_debug_snapshot!(conf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,10 @@ pub async fn run(args: Cli) -> Result<()> {
     cwd.clean_windows_path();
 
     let opts = args.opts().unwrap();
+    let bin_args = args.bin_args();
 
     let watch = matches!(args.command, Commands::Watch(_));
-    let config = Config::load(opts, &cwd, &manifest_path, watch).dot()?;
+    let config = Config::load(opts, &cwd, &manifest_path, watch, bin_args).dot()?;
     env::set_current_dir(&config.working_dir).dot()?;
     log::debug!(
         "Path working dir {}",

--- a/src/service/serve.rs
+++ b/src/service/serve.rs
@@ -59,6 +59,7 @@ struct ServerProcess {
     process: Option<Child>,
     envs: Vec<(&'static str, String)>,
     binary: Utf8PathBuf,
+    bin_args: Option<Vec<String>>,
 }
 
 impl ServerProcess {
@@ -67,6 +68,7 @@ impl ServerProcess {
             process: None,
             envs: proj.to_envs(),
             binary: proj.bin.exe_file.clone(),
+            bin_args: proj.bin.bin_args.clone(),
         }
     }
 
@@ -134,8 +136,18 @@ impl ServerProcess {
                 bin.clone()
             };
 
+            let bin_args = match &self.bin_args {
+                Some(bin_args) => bin_args.as_slice(),
+                None => &[],
+            };
+
             log::debug!("Serve running {}", GRAY.paint(bin_path.as_str()));
-            let cmd = Some(Command::new(bin_path).envs(self.envs.clone()).spawn()?);
+            let cmd = Some(
+                Command::new(bin_path)
+                    .envs(self.envs.clone())
+                    .args(bin_args)
+                    .spawn()?,
+            );
             let port = self
                 .envs
                 .iter()


### PR DESCRIPTION
For #245 

So we can pass command line arguments to bin, such as `cargo leptos watch -v -- --foo`.