### PR TITLE
Fix help message for verbosity option

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -48,7 +48,7 @@ pub struct Opts {
     #[arg(long)]
     pub bin_cargo_args: Option<Vec<String>>,
 
-    /// Verbosity (none: info, errors & warnings, -v: verbose, --vv: very verbose).
+    /// Verbosity (none: info, errors & warnings, -v: verbose, -vv: very verbose).
     #[arg(short, action = clap::ArgAction::Count)]
     pub verbose: u8,
 }


### PR DESCRIPTION
Fixes issue #247 

Tell the user to use the `-vv` flag for very verbose, instead of the incorrect `--vv`.