### PR TITLE
chore: update default version of wasm-opt

### DIFF
--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -402,7 +402,7 @@ impl Command for CommandWasmOpt {
         "wasm-opt"
     }
     fn default_version(&self) -> &'static str {
-        "version_112"
+        "version_117"
     }
     fn env_var_version_name(&self) -> &'static str {
         ENV_VAR_LEPTOS_WASM_OPT_VERSION


### PR DESCRIPTION
It looks like that version is the one that includes the aarch64 binary for linux 

https://github.com/WebAssembly/binaryen/releases/tag/version_117