### PR TITLE
Fix cargo args

### DIFF
--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -96,7 +96,10 @@ impl LibPackage {
         }
 
         let front_target_path = metadata.target_directory.join("front");
-        let cargo_args = cli.lib_cargo_args.clone();
+        let cargo_args = cli
+            .lib_cargo_args
+            .clone()
+            .or_else(|| config.lib_cargo_args.clone());
 
         Ok(Self {
             name,

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -198,7 +198,7 @@ pub struct ProjectConfig {
     /// the command to run instead of "cargo" when building the server
     pub bin_cargo_command: Option<String>,
     /// cargo flags to pass to cargo when running the server. Overriden by bin_cargo_command
-    pub bin_cargo_args: Option<String>,
+    pub bin_cargo_args: Option<Vec<String>>,
     /// An optional override, if you've changed the name of your bin file in your project you'll need to set it here as well.
     pub bin_exe_name: Option<String>,
     #[serde(default)]
@@ -208,7 +208,7 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub lib_default_features: bool,
     /// cargo flags to pass to cargo when building the WASM frontend
-    pub lib_cargo_args: Option<String>,
+    pub lib_cargo_args: Option<Vec<String>>,
     #[serde(default)]
     pub bin_features: Vec<String>,
     #[serde(default)]


### PR DESCRIPTION
`*-cargo-args` was expected to be a `String` even tough the docs shows them as arrays.

The empty cli flag for `lib-cargo-args` no longer overrides the one provided in the config.
I have not further investigated `bin-cargo-args`.