### PR TITLE
tweaks for hash_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ bin-target = "my-bin-name"
 
 # Enables additional file hashes on outputted css, js, and wasm files
 #
-# Optional: Defaults to false. Can also be set with the LEPTOS_HASH_FILES=false env var
+# Optional: Defaults to false. Can also be set with the LEPTOS_HASH_FILES=false env var (must be set at runtime too)
 hash-files = false
 
 # Sets the name for the file cargo-leptos uses to track the most recent hashes
 #
 # Optional: Defaults to "hash.txt". Can also be set with the LEPTOS_HASH_FILE_NAME="hash.txt" env var
-hash-file-name = false
+hash-file-name = "hash.txt"
 
 # The features to use when compiling all targets
 #

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -47,6 +47,7 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_END2END_CMD" => conf.end2end_cmd = Some(val),
             "LEPTOS_END2END_DIR" => conf.end2end_dir = Some(Utf8PathBuf::from(val)),
             "LEPTOS_HASH_FILES" => conf.hash_files = val.parse()?,
+            "LEPTOS_HASH_FILE_NAME" => conf.hash_file_name = Some(val.parse()?),
             "LEPTOS_BROWSERQUERY" => conf.browserquery = val,
             "LEPTOS_BIN_TARGET_TRIPLE" => conf.bin_target_triple = Some(val),
             "LEPTOS_BIN_TARGET_DIR" => conf.bin_target_dir = Some(val),

--- a/src/config/hash_file.rs
+++ b/src/config/hash_file.rs
@@ -1,5 +1,6 @@
-use crate::config::Profile;
 use camino::Utf8PathBuf;
+
+use super::bin_package::BinPackage;
 
 pub struct HashFile {
     pub abs: Utf8PathBuf,
@@ -7,16 +8,13 @@ pub struct HashFile {
 }
 
 impl HashFile {
-    pub fn new(
-        target_directory: &Utf8PathBuf,
-        profile: &Profile,
-        rel: Option<&Utf8PathBuf>,
-    ) -> Self {
+    pub fn new(bin: &BinPackage, rel: Option<&Utf8PathBuf>) -> Self {
         let rel = rel
             .cloned()
             .unwrap_or(Utf8PathBuf::from("hash.txt".to_string()));
 
-        let abs = target_directory.join(profile.to_string()).join(&rel);
+        let exe_file_dir = bin.exe_file.parent().unwrap();
+        let abs = bin.abs_dir.join(exe_file_dir).join(&rel);
 
         Self { abs, rel }
     }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -93,11 +93,7 @@ impl Project {
 
             let bin = BinPackage::resolve(cli, metadata, &project, &config, bin_args)?;
 
-            let hash_file = HashFile::new(
-                &metadata.target_directory,
-                &bin.profile,
-                config.hash_file.as_ref(),
-            );
+            let hash_file = HashFile::new(&bin, config.hash_file_name.as_ref());
 
             let proj = Project {
                 working_dir: metadata.workspace_root.clone(),
@@ -168,7 +164,7 @@ pub struct ProjectConfig {
     pub site_pkg_dir: Utf8PathBuf,
     pub style_file: Option<Utf8PathBuf>,
     /// text file where the hashes of the frontend files are stored
-    pub hash_file: Option<Utf8PathBuf>,
+    pub hash_file_name: Option<Utf8PathBuf>,
     /// whether to hash the frontend files content and add them to the file names
     #[serde(default = "default_hash_files")]
     pub hash_files: bool,


### PR DESCRIPTION
I'd appreciate a code review on this as i'm pretty new to contributing to open source rust.

1.

In Cargo.toml one can add
hash-file-name="my-hash-file.txt"

(it was erroneously checking for "hash-file" instead of "hash-file-name"). This is potentially a breaking change but shouldn't affect anyone since it was a bug to begin with?

2.
Ensure the environment variable LEPTOS_HASH_FILE_NAME is allowed.

3.
fix the directory of hash.txt when cross compiling by using the exact directory that the binary is in.

Cheers


fixes: #278 


