### PR TITLE
Run tailwindcss command instead of tailwind

### DIFF
--- a/src/compile/tailwind.rs
+++ b/src/compile/tailwind.rs
@@ -21,7 +21,7 @@ pub async fn compile_tailwind(
         create_default_tailwind_config(tw_conf).await?;
     }
 
-    let (line, process) = tailwind_process("tailwind", tw_conf).await?;
+    let (line, process) = tailwind_process("tailwindcss", tw_conf).await?;
 
     match wait_piped_interruptible("Tailwind", process, Interrupt::subscribe_any()).await? {
         CommandResult::Success(output) => {


### PR DESCRIPTION
Small change to the CLI command used to run tailwind. I've run into a difficult to debug error that I suspect is caused by what is there before this change. Regardless, [the page on Tailwind CLI](https://tailwindcss.com/docs/installation) uses `tailwindcss` as the command as opposed to `tailwind`.