### PR TITLE
Minor: actions/checkout now consistently using version 4.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
         - name: "Checkout repo"
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
 
         - name: "Install wasm32-unknown-unknown"
           uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
over in PR Maintenance patch #274 

I initially tried to generate a series of small upgrade patches.
but due to the messy coupling between crates many changes have to be pushed into 
a single PR 

Today I am trying to isolate a subtle bug "new tests are passing in Ubuntu - but failing on Windows" 

To reduce complexity I am re-reviewing my own work and peeling off isolated micro issues 
into isolated PRs.

This is going to be the first of many,