### PR TITLE
fix: edge case for path_dependency == workspace_root (Fixes #303)

### DIFF
--- a/src/ext/cargo.rs
+++ b/src/ext/cargo.rs
@@ -101,9 +101,13 @@ impl MetadataExt for Metadata {
         self.path_dependencies(id)
             .iter()
             .map(|p| {
-                p.unbase(root)
-                    .unwrap_or_else(|_| p.to_path_buf())
-                    .join("src")
+                let path = p.unbase(root).unwrap_or_else(|_| p.to_path_buf());
+
+                if path == "." {
+                    Utf8PathBuf::from("src")
+                } else {
+                    path.join("src")
+                }
             })
             .collect()
     }


### PR DESCRIPTION
I'm unfamiliar with the camino crate so I'm not sure if maybe there's a more elegant way to write this.