### PR TITLE
Minor: clippy fixes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,6 +2935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "supports-color"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,7 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac38cd938ce20693b58b26a5d1926a46074db09cf90a251d83cf17cdaea6031"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "dashmap",
  "either",
  "indexmap 2.2.6",
@@ -3071,7 +3077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754058388d4f51df61f9aced73dfca96d81fed1c0a46583dc7b3da07688af80d"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "once_cell",
  "pathdiff",
  "serde",
@@ -3675,7 +3681,7 @@ version = "0.184.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "565a76c4ca47ce31d78301c0beab878e4c2cb4f624691254d834ec8c0e236755"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "dashmap",
  "indexmap 2.2.6",
  "once_cell",
@@ -3859,12 +3865,6 @@ dependencies = [
  "swc_macros_common",
  "syn 2.0.57",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"

--- a/src/compile/hash.rs
+++ b/src/compile/hash.rs
@@ -53,8 +53,8 @@ fn compute_front_file_hashes(proj: &Project) -> Result<HashMap<Utf8PathBuf, Stri
 
     while let Some(path) = stack.pop() {
         if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries {
-                if let Ok(entry) = entry {
+            for entry in entries.flatten() {
+
                     let path = entry.path();
 
                     if path.is_file() {
@@ -69,7 +69,6 @@ fn compute_front_file_hashes(proj: &Project) -> Result<HashMap<Utf8PathBuf, Stri
                     } else if path.is_dir() {
                         stack.push(path);
                     }
-                }
             }
         }
     }

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     compile::front::build_cargo_front_cmd,
     config::{Config, Opts},
 };
-use insta::assert_display_snapshot;
+use insta::assert_snapshot;
 use tokio::process::Command;
 
 use super::server::build_cargo_server_cmd;
@@ -62,7 +62,7 @@ fn test_project_dev() {
     LEPTOS_WATCH=true";
     assert_eq!(ENV_REF, envs);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
+    assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
@@ -82,7 +82,7 @@ fn test_project_release() {
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr --release");
+    assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr --release");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
@@ -130,7 +130,7 @@ fn test_workspace_project1() {
 
     assert_eq!(ENV_REF, envs);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=server-package --bin=server-package --no-default-features");
+    assert_snapshot!(cargo, @"cargo build --package=server-package --bin=server-package --no-default-features");
 
     let mut command = Command::new("cargo");
     let (envs, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);
@@ -150,7 +150,7 @@ fn test_workspace_project2() {
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[1], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=project2 --bin=project2 --no-default-features --features=ssr");
+    assert_snapshot!(cargo, @"cargo build --package=project2 --bin=project2 --no-default-features --features=ssr");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[1], &mut command);
@@ -174,7 +174,7 @@ fn test_extra_cargo_args() {
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_server_cmd("build", &conf.projects[0], &mut command);
 
-    assert_display_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr -j 16");
+    assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr -j 16");
 
     let mut command = Command::new("cargo");
     let (_, cargo) = build_cargo_front_cmd("build", true, &conf.projects[0], &mut command);

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -85,8 +85,8 @@ impl BinPackage {
         let exe_file = {
             let file_ext = if cfg!(target_os = "windows") {
                 "exe"
-            } else if &config.bin_target_triple == &Some("wasm32-wasi".to_string())
-                || &config.bin_target_triple == &Some("wasm32-unknown-unknown".to_string())
+            } else if config.bin_target_triple == Some("wasm32-wasi".to_string())
+                || config.bin_target_triple == Some("wasm32-unknown-unknown".to_string())
             {
                 "wasm"
             } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ async fn workspace_build() {
     // when running the current working directory is changed to the manifest path.
     let site_dir = Utf8PathBuf::from("target/site");
 
-    //insta::assert_display_snapshot!(site_dir.ls_ascii(0).unwrap_or_default());
+    //insta::assert_snapshot!(site_dir.ls_ascii(0).unwrap_or_default());
 }
 
 // TODO: `cargo-leptos` sets the cwd which is a global env
@@ -42,5 +42,5 @@ async fn workspace_build() {
 //     // when running the current working directory is changed to the manifest path.
 //     let site_dir = Utf8PathBuf::from("target/site");
 
-//     insta::assert_display_snapshot!(site_dir.ls_ascii(0).unwrap_or_default());
+//     insta::assert_snapshot!(site_dir.ls_ascii(0).unwrap_or_default());
 // }


### PR DESCRIPTION
Just picking up clippy lints.

Lots of minor things, of most significance,  now using .flattern() where possible.

```rustlang
-            for entry in entries {
-                if let Ok(entry) = entry {
+            for entry in entries.flatten() {
```