### PR TITLE
Draft: Conditionally minify css

### DIFF
--- a/src/compile/style.rs
+++ b/src/compile/style.rs
@@ -92,11 +92,11 @@ fn browser_lists(query: &str) -> Result<Option<Browsers>> {
 async fn process_css(proj: &Project, css: String) -> Result<Product> {
     let browsers = browser_lists(&proj.style.browserquery).context("leptos.style.browserquery")?;
     let targets = Targets::from(browsers);
-
+    let minify = proj.release && proj.css_minify;
     let mut stylesheet =
         StyleSheet::parse(&css, ParserOptions::default()).map_err(|e| anyhow!("{e}"))?;
 
-    if proj.release {
+    if minify {
         let minify_options = MinifyOptions {
             targets,
             ..Default::default()
@@ -106,7 +106,7 @@ async fn process_css(proj: &Project, css: String) -> Result<Product> {
 
     let options = PrinterOptions::<'_> {
         targets,
-        minify: proj.release,
+        minify,
         ..Default::default()
     };
 

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -11,6 +11,7 @@ fn release_opts() -> Opts {
     Opts {
         release: true,
         js_minify: true,
+        css_minify: true,
         precompress: false, // if set to true, testing could take quite a while longer
         hot_reload: false,
         project: None,
@@ -27,6 +28,7 @@ fn dev_opts() -> Opts {
     Opts {
         release: false,
         js_minify: false,
+        css_minify: false,
         precompress: false,
         hot_reload: false,
         project: None,
@@ -57,6 +59,7 @@ fn test_project_dev() {
     LEPTOS_LIB_DIR=. \
     LEPTOS_BIN_DIR=. \
     LEPTOS_JS_MINIFY=false \
+    LEPTOS_CSS_MINIFY=false \
     LEPTOS_HASH_FILES=true \
     LEPTOS_HASH_FILE_NAME=hash.txt \
     LEPTOS_WATCH=true";
@@ -106,6 +109,7 @@ fn test_workspace_project1() {
     LEPTOS_LIB_DIR=project1\\front \
     LEPTOS_BIN_DIR=project1\\server \
     LEPTOS_JS_MINIFY=false \
+    LEPTOS_CSS_MINIFY=false \
     LEPTOS_HASH_FILES=false \
     LEPTOS_WATCH=true"
     } else {
@@ -118,6 +122,7 @@ fn test_workspace_project1() {
     LEPTOS_LIB_DIR=project1/front \
     LEPTOS_BIN_DIR=project1/server \
     LEPTOS_JS_MINIFY=false \
+    LEPTOS_CSS_MINIFY=false \
     LEPTOS_HASH_FILES=false \
     LEPTOS_WATCH=true"
     };

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -59,6 +59,10 @@ pub struct Opts {
     /// Minify javascript assets with swc. Applies to release builds only.
     #[arg(long, default_value = "true", value_parser=clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
     pub js_minify: bool,
+
+    /// Minify javascript assets with lightningcss. Applies to release builds only.
+    #[arg(long, default_value = "true", value_parser=clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
+    pub css_minify: bool,
 }
 
 #[derive(Debug, Clone, Parser, PartialEq, Default)]

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -53,6 +53,7 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_BIN_TARGET_DIR" => conf.bin_target_dir = Some(val),
             "LEPTOS_BIN_CARGO_COMMAND" => conf.bin_cargo_command = Some(val),
             "LEPTOS_JS_MINIFY" => conf.js_minify = val.parse()?,
+            "LEPTOS_CSS_MINIFY" => conf.css_minify = val.parse()?,
             // put these here to suppress the warning, but there's no
             // good way at the moment to pull the ProjectConfig all the way to Exe
             exe::ENV_VAR_LEPTOS_TAILWIND_VERSION => {}

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -47,6 +47,7 @@ pub struct Project {
     pub hash_file: HashFile,
     pub hash_files: bool,
     pub js_minify: bool,
+    pub css_minify: bool,
 }
 
 impl Debug for Project {
@@ -60,6 +61,7 @@ impl Debug for Project {
             .field("release", &self.release)
             .field("precompress", &self.precompress)
             .field("js_minify", &self.js_minify)
+            .field("css_minify", &self.css_minify)
             .field("hot_reload", &self.hot_reload)
             .field("site", &self.site)
             .field("end2end", &self.end2end)
@@ -116,6 +118,7 @@ impl Project {
                 hash_file,
                 hash_files: config.hash_files,
                 js_minify: cli.release && cli.js_minify && config.js_minify,
+                css_minify: cli.release && cli.css_minify && config.css_minify,
             };
             resolved.push(Arc::new(proj));
         }
@@ -143,6 +146,7 @@ impl Project {
             ("LEPTOS_LIB_DIR", self.lib.rel_dir.to_string()),
             ("LEPTOS_BIN_DIR", self.bin.rel_dir.to_string()),
             ("LEPTOS_JS_MINIFY", self.js_minify.to_string()),
+            ("LEPTOS_CSS_MINIFY", self.css_minify.to_string()),
             ("LEPTOS_HASH_FILES", self.hash_files.to_string()),
         ];
         if self.hash_files {
@@ -167,6 +171,8 @@ pub struct ProjectConfig {
     #[serde(default = "default_pkg_dir")]
     pub site_pkg_dir: Utf8PathBuf,
     pub style_file: Option<Utf8PathBuf>,
+    #[serde(default = "default_css_minify")]
+    pub css_minify: bool,
     /// text file where the hashes of the frontend files are stored
     pub hash_file_name: Option<Utf8PathBuf>,
     /// whether to hash the frontend files content and add them to the file names
@@ -401,5 +407,9 @@ fn default_hash_files() -> bool {
 }
 
 fn default_js_minify() -> bool {
+    true
+}
+
+fn default_css_minify() -> bool {
     true
 }

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -56,6 +56,7 @@ Config {
             release: false,
             precompress: false,
             js_minify: false,
+            css_minify: false,
             hot_reload: false,
             site: Site {
                 addr: 127.0.0.1:3000,
@@ -129,6 +130,7 @@ Config {
             release: false,
             precompress: false,
             js_minify: false,
+            css_minify: false,
             hot_reload: false,
             site: Site {
                 addr: 127.0.0.1:3000,
@@ -160,6 +162,7 @@ Config {
         wasm_debug: false,
         verbose: 0,
         js_minify: false,
+        css_minify: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -65,6 +65,7 @@ Config {
             release: false,
             precompress: false,
             js_minify: false,
+            css_minify: false,
             hot_reload: false,
             site: Site {
                 addr: 127.0.0.1:3000,
@@ -98,6 +99,7 @@ Config {
         wasm_debug: false,
         verbose: 0,
         js_minify: false,
+        css_minify: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -60,6 +60,7 @@ Config {
             release: false,
             precompress: false,
             js_minify: false,
+            css_minify: false,
             hot_reload: false,
             site: Site {
                 addr: 127.0.0.1:3000,
@@ -91,6 +92,7 @@ Config {
         wasm_debug: false,
         verbose: 0,
         js_minify: false,
+        css_minify: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -56,6 +56,7 @@ Config {
             release: false,
             precompress: false,
             js_minify: false,
+            css_minify: false,
             hot_reload: false,
             site: Site {
                 addr: 127.0.0.1:3000,
@@ -89,6 +90,7 @@ Config {
         wasm_debug: false,
         verbose: 0,
         js_minify: false,
+        css_minify: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -60,6 +60,7 @@ Config {
             release: false,
             precompress: false,
             js_minify: false,
+            css_minify: false,
             hot_reload: false,
             site: Site {
                 addr: 127.0.0.1:3000,
@@ -93,6 +94,7 @@ Config {
         wasm_debug: false,
         verbose: 0,
         js_minify: false,
+        css_minify: false,
     },
     watch: true,
     ..

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,6 +4,7 @@ fn opts(project: Option<&str>) -> crate::config::Opts {
     crate::config::Opts {
         release: false,
         js_minify: false,
+        css_minify: false,
         precompress: false,
         hot_reload: false,
         project: project.map(|s| s.to_string()),


### PR DESCRIPTION
Adds `css_minify` option in line with https://github.com/leptos-rs/cargo-leptos/commit/7b316cfc7ae7264084a7c737eec99e0c653f2db5 (see also https://github.com/leptos-rs/cargo-leptos/pull/285)

I am using DaisyUI and currently using lightningcss seems to break it (https://github.com/leptos-rs/cargo-leptos/issues/241)

I saw the `js_minify` option that was just added, so i think a `css_minify` should also exist which works in the same way.

This is logically complete, and working. Yet setting minify to false for lightningcss did not solve my issues with the faulty processing.
I put this up as a Draft for now to allow an easier overview/discussion.
