### PR TITLE
Fix issue with multi word bin commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "semver 1.0.22",
  "serde",
  "serde_json",
+ "shlex",
  "swc",
  "swc_common",
  "tar",
@@ -2734,6 +2735,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ md-5 = "0.10.6"
 base64ct = { version = "1.6.0", features = ["alloc"] }
 swc = "0.275.1"
 swc_common = "0.33.26"
+shlex = "1.3.0"
 
 [dev-dependencies]
 insta = { version = "1.31.0", features = ["yaml"] }

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -56,7 +56,7 @@ pub fn server_cargo_process(cmd: &str, proj: &Project) -> Result<(String, String
     let raw_command = proj.bin.cargo_command.as_deref().unwrap_or("cargo");
     let mut command_iter = Shlex::new(raw_command);
 
-    if command_iter.had_error(){
+    if command_iter.had_error{
         panic!("bin-cargo-command cannot contain escaped quotes. Not sure why you'd want to")
     }
 

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -118,6 +118,8 @@ impl BinPackage {
         } else {
             src_paths.push(rel_dir.join("src"));
         }
+
+        log::debug!("BEFORE BIN {:?}", config.bin_cargo_command);
         Ok(Self {
             name,
             abs_dir,


### PR DESCRIPTION
I wanted to use a different cargo command with two words in it, which does not work in cargo leptos