### PR TITLE
Change the default wasm-opt settings to optimize for size

### DIFF
--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -173,7 +173,7 @@ async fn optimize(
 ) -> Result<CommandResult<()>> {
     let wasm_opt = Exe::WasmOpt.get().await.dot()?;
 
-    let args = [file.as_str(), "-Os", "-o", file.as_str()];
+    let args = [file.as_str(), "-Oz", "-o", file.as_str()];
     let process = Command::new(wasm_opt)
         .args(args)
         .spawn()


### PR DESCRIPTION
Currently wasm-opt is set to compile for speed, but if we are setting a default for wasm-opt for users than I believe most people would want it optimizing for size instead.