### PR TITLE
fix for hash_file to work in workspace and target

### DIFF
--- a/src/config/hash_file.rs
+++ b/src/config/hash_file.rs
@@ -8,13 +8,13 @@ pub struct HashFile {
 }
 
 impl HashFile {
-    pub fn new(bin: &BinPackage, rel: Option<&Utf8PathBuf>) -> Self {
+    pub fn new(workspace_root: &Utf8PathBuf, bin: &BinPackage, rel: Option<&Utf8PathBuf>) -> Self {
         let rel = rel
             .cloned()
             .unwrap_or(Utf8PathBuf::from("hash.txt".to_string()));
 
         let exe_file_dir = bin.exe_file.parent().unwrap();
-        let abs = bin.abs_dir.join(exe_file_dir).join(&rel);
+        let abs = workspace_root.join(exe_file_dir).join(&rel);
 
         Self { abs, rel }
     }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -95,7 +95,11 @@ impl Project {
 
             let bin = BinPackage::resolve(cli, metadata, &project, &config, bin_args)?;
 
-            let hash_file = HashFile::new(&bin, config.hash_file_name.as_ref());
+            let hash_file = HashFile::new(
+                &metadata.workspace_root,
+                &bin,
+                config.hash_file_name.as_ref(),
+            );
 
             let proj = Project {
                 working_dir: metadata.workspace_root.clone(),


### PR DESCRIPTION
Fix for #320, partially reverts #282.
I tested it in my project and it works, 
with and without LEPTOS_BIN_TARGET_TRIPLE, with and without LEPTOS_BIN_TARGET_DIR

I could not yet build the workspace example, it throws an error for "time" crate - error[E0282]: type annotations needed for `Box<_>`

I noticed that it will fail with error if there is no target directory yet, like x86_64-unknown-linux-gnu/release, so I had to create it manually for now. I'll recheck later and will create an issue if need.
Error: No such file or directory (os error 2)

