### PR TITLE
hash.txt path correction

### DIFF
--- a/src/config/hash_file.rs
+++ b/src/config/hash_file.rs
@@ -8,13 +8,12 @@ pub struct HashFile {
 }
 
 impl HashFile {
-    pub fn new(workspace_root: &Utf8PathBuf, bin: &BinPackage, rel: Option<&Utf8PathBuf>) -> Self {
+    pub fn new(workspace_root: &Utf8PathBuf, rel: Option<&Utf8PathBuf>) -> Self {
         let rel = rel
             .cloned()
             .unwrap_or(Utf8PathBuf::from("hash.txt".to_string()));
 
-        let exe_file_dir = bin.exe_file.parent().unwrap();
-        let abs = workspace_root.join(exe_file_dir).join(&rel);
+        let abs = workspace_root.join(&rel);
 
         Self { abs, rel }
     }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -97,7 +97,6 @@ impl Project {
 
             let hash_file = HashFile::new(
                 &metadata.workspace_root,
-                &bin,
                 config.hash_file_name.as_ref(),
             );
 


### PR DESCRIPTION
hash.txt file was being looked for at the bin exec path but lives at the workspace root level 