### PR TITLE
bump swc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,7 @@ jobs:
             workspaces: |
               .
               examples/workspace
-        - name: "Install wasm-bindgen-cli"
-          run: cargo install -f wasm-bindgen-cli --version 0.2.93
-
+              
         - name: "Run cargo test --features=full_tests"
           uses: actions-rs/cargo@v1
           with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
             workspaces: |
               .
               examples/workspace
+        - name: "Install wasm-bindgen-cli"
+          run: cargo install -f wasm-bindgen-cli --version 0.2.93
 
         - name: "Run cargo test --features=full_tests"
           uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ semver = "1.0.19"
 async-trait = "0.1.72"
 md-5 = "0.10.6"
 base64ct = { version = "1.6.0", features = ["alloc"] }
-swc = "0.283.0"
+swc = "0.284.1"
 swc_common = "0.37.2"
 shlex = "1.3.0"
 

--- a/src/config/hash_file.rs
+++ b/src/config/hash_file.rs
@@ -8,13 +8,12 @@ pub struct HashFile {
 }
 
 impl HashFile {
-    pub fn new(workspace_root: &Utf8PathBuf, bin: &BinPackage, rel: Option<&Utf8PathBuf>) -> Self {
+    pub fn new(workspace_root: &Utf8PathBuf, rel: Option<&Utf8PathBuf>) -> Self {
         let rel = rel
             .cloned()
             .unwrap_or(Utf8PathBuf::from("hash.txt".to_string()));
 
-        let exe_file_dir = bin.exe_file.parent().unwrap();
-        let abs = workspace_root.join(exe_file_dir).join(&rel);
+        let abs = workspace_root.join(&rel);
 
         Self { abs, rel }
     }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -97,7 +97,6 @@ impl Project {
 
             let hash_file = HashFile::new(
                 &metadata.workspace_root,
-                &bin,
                 config.hash_file_name.as_ref(),
             );
 


### PR DESCRIPTION
bump swc, 
currently cargo install cargo-leptos is broken because swc needed to cover a decorator in a match statement, they pushed that a few hours ago and this bump fixes installing cargo leptos via cargo.