### PR TITLE
create parent dir for hashfile if not exists

### DIFF
--- a/src/compile/hash.rs
+++ b/src/compile/hash.rs
@@ -10,6 +10,9 @@ use std::fs;
 ///Adds hashes to the filenames of the css, js, and wasm files in the output
 pub fn add_hashes_to_site(proj: &Project) -> Result<()> {
     let files_to_hashes = compute_front_file_hashes(proj).dot()?;
+
+    log::debug!("Hash computed: {files_to_hashes:?}");
+
     let renamed_files = rename_files(&files_to_hashes).dot()?;
 
     replace_in_file(
@@ -17,6 +20,14 @@ pub fn add_hashes_to_site(proj: &Project) -> Result<()> {
         &renamed_files,
         &proj.site.root_relative_pkg_dir(),
     );
+
+    fs::create_dir_all(
+        proj.hash_file
+            .abs
+            .parent()
+            .with_context(|| format!("no parent dir for {}", proj.hash_file.abs))?,
+    )
+    .with_context(|| format!("Failed to create parent dir for {}", proj.hash_file.abs))?;
 
     fs::write(
         &proj.hash_file.abs,
@@ -41,7 +52,10 @@ pub fn add_hashes_to_site(proj: &Project) -> Result<()> {
                 .ok_or(anyhow::anyhow!("no extension"))?,
             files_to_hashes[&proj.style.site_file.dest]
         ),
-    )?;
+    )
+    .with_context(|| format!("Failed to write hash file to {}", proj.hash_file.abs))?;
+
+    log::debug!("Hash written to {}", proj.hash_file.abs);
 
     Ok(())
 }
@@ -52,29 +66,28 @@ fn compute_front_file_hashes(proj: &Project) -> Result<HashMap<Utf8PathBuf, Stri
     let mut stack = vec![proj.site.root_relative_pkg_dir().into_std_path_buf()];
 
     while let Some(path) = stack.pop() {
-        if let Ok(entries) = std::fs::read_dir(path) {
+        if let Ok(entries) = fs::read_dir(path) {
             for entry in entries.flatten() {
+                let path = entry.path();
 
-                    let path = entry.path();
-
-                    if path.is_file() {
-                        if let Some(extension) = path.extension() {
-                            if extension == "css" && path != proj.style.site_file.dest {
-                                continue;
-                            }
+                if path.is_file() {
+                    if let Some(extension) = path.extension() {
+                        if extension == "css" && path != proj.style.site_file.dest {
+                            continue;
                         }
-
-                        let hash = Base64UrlUnpadded::encode_string(
-                            &Md5::new().chain_update(fs::read(&path)?).finalize(),
-                        );
-
-                        files_to_hashes.insert(
-                            Utf8PathBuf::from_path_buf(path).expect("invalid path"),
-                            hash,
-                        );
-                    } else if path.is_dir() {
-                        stack.push(path);
                     }
+
+                    let hash = Base64UrlUnpadded::encode_string(
+                        &Md5::new().chain_update(fs::read(&path)?).finalize(),
+                    );
+
+                    files_to_hashes.insert(
+                        Utf8PathBuf::from_path_buf(path).expect("invalid path"),
+                        hash,
+                    );
+                } else if path.is_dir() {
+                    stack.push(path);
+                }
             }
         }
     }
@@ -97,7 +110,8 @@ fn rename_files(
             path.extension().ok_or(anyhow::anyhow!("no extension"))?,
         ));
 
-        fs::rename(path, &new_path)?;
+        fs::rename(path, &new_path)
+            .with_context(|| format!("Failed to rename {path} to {new_path}"))?;
 
         old_to_new_paths.insert(path.clone(), new_path);
     }
@@ -110,7 +124,7 @@ fn replace_in_file(
     old_to_new_paths: &HashMap<Utf8PathBuf, Utf8PathBuf>,
     root_dir: &Utf8PathBuf,
 ) {
-    let mut contents = fs::read_to_string(path).expect("could not read file");
+    let mut contents = fs::read_to_string(path).expect(&format!("could not read file {}", path));
 
     for (old_path, new_path) in old_to_new_paths {
         let old_path = old_path


### PR DESCRIPTION
Relates to #347

This makes sure that hashing works after `cargo clean`.