### PR TITLE
Fix hashing in workspaces and single crates

### DIFF
--- a/src/config/hash_file.rs
+++ b/src/config/hash_file.rs
@@ -2,21 +2,29 @@ use camino::Utf8PathBuf;
 
 use super::bin_package::BinPackage;
 
-
 pub struct HashFile {
     pub abs: Utf8PathBuf,
     pub rel: Utf8PathBuf,
 }
 
 impl HashFile {
-pub fn new(bin: &BinPackage, rel: Option<&Utf8PathBuf>) -> Self {
+    pub fn new(
+        workspace_root: Option<&Utf8PathBuf>,
+        bin: &BinPackage,
+        rel: Option<&Utf8PathBuf>,
+    ) -> Self {
         let rel = rel
             .cloned()
             .unwrap_or(Utf8PathBuf::from("hash.txt".to_string()));
 
         let exe_file_dir = bin.exe_file.parent().unwrap();
-        let abs = bin.abs_dir.join(exe_file_dir).join(&rel);
-
+        let abs;
+        if let Some(workspace_root) = workspace_root {
+            log::debug!("BIN PARENT: {}", bin.exe_file.parent().unwrap());
+            abs = workspace_root.join(exe_file_dir).join(&rel);
+        } else {
+            abs = bin.abs_dir.join(exe_file_dir).join(&rel);
+        }
         Self { abs, rel }
     }
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -95,10 +95,17 @@ impl Project {
 
             let bin = BinPackage::resolve(cli, metadata, &project, &config, bin_args)?;
 
-            let hash_file = HashFile::new(
-                &bin,
-                config.hash_file_name.as_ref(),
-            );
+            // If there's more than 1 workspace member, we're a workspace. Probably
+            let is_workspace = metadata.workspace_members.len() > 1;
+            log::debug!("Detected Workspace: {is_workspace}");
+            let hash_file = match is_workspace {
+                true => HashFile::new(
+                    Some(&metadata.workspace_root),
+                    &bin,
+                    config.hash_file_name.as_ref(),
+                ),
+                false => HashFile::new(None, &bin, config.hash_file_name.as_ref()),
+            };
 
             let proj = Project {
                 working_dir: metadata.workspace_root.clone(),


### PR DESCRIPTION
This change should put the hashing file name issue to bed, closing #347 