### PR TITLE
deps: Update psm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
+checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
psm@0.1.23 doesn't build for aarch64-pc-windows-gnullvm target. newer version fixed this issue