### PR TITLE
fix for non-windows target cross compile on windows

### DIFF
--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -83,7 +83,12 @@ impl BinPackage {
             &config.bin_profile_dev,
         );
         let exe_file = {
-            let file_ext = if cfg!(target_os = "windows") {
+            let file_ext = if cfg!(target_os = "windows")
+                && config
+                    .bin_target_triple
+                    .as_ref()
+                    .is_none_or(|triple| triple.contains("-pc-windows-"))
+            {
                 "exe"
             } else if config
                 .bin_target_triple


### PR DESCRIPTION
Before:
Cargo-leptos was finding .exe file after building server when cross compiling to non-windows targets which does not use .exe extensions at all.

After:
This commit fixes it to use .exe extension only when the target machine is also windows.

Error log:
Error: at `D:\a\cargo-leptos\cargo-leptos\src\compile\server.rs:40:22` Caused by:
    0: at `D:\a\cargo-leptos\cargo-leptos\src\service\site.rs:117:44`
    1: Could not read "target\\aarch64-unknown-linux-gnu\\wasm-release\\leptos.exe" at `D:\a\cargo-leptos\cargo-leptos\src\ext\fs.rs:44:10`
    2: No such file or directory (os error 2)