### PR TITLE
feat: Add server function configs

### DIFF
--- a/examples/project/Cargo.toml
+++ b/examples/project/Cargo.toml
@@ -125,3 +125,4 @@ hash-files = true
 
 server-fn-prefix = "/custom/prefix"
 disable-server-fn-hash = true
+server-fn-mod-path = true

--- a/examples/project/Cargo.toml
+++ b/examples/project/Cargo.toml
@@ -46,25 +46,25 @@ opt-level = 'z'
 [features]
 default = ["ssr"]
 hydrate = [
-  "leptos/hydrate",
-  "leptos_meta/hydrate",
-  "leptos_router/hydrate",
-  "dep:wasm-bindgen",
-  "dep:console_log",
-  "dep:console_error_panic_hook",
+    "leptos/hydrate",
+    "leptos_meta/hydrate",
+    "leptos_router/hydrate",
+    "dep:wasm-bindgen",
+    "dep:console_log",
+    "dep:console_error_panic_hook",
 ]
 ssr = [
-  "leptos/ssr",
-  "leptos_meta/ssr",
-  "leptos_router/ssr",
-  "dep:leptos_actix",
-  "dep:reqwest",
-  "dep:actix-web",
-  "dep:actix-files",
-  "dep:futures",
-  "dep:simple_logger",
-  "dep:serde_json",
-  "dep:dotenvy",
+    "leptos/ssr",
+    "leptos_meta/ssr",
+    "leptos_router/ssr",
+    "dep:leptos_actix",
+    "dep:reqwest",
+    "dep:actix-web",
+    "dep:actix-files",
+    "dep:futures",
+    "dep:simple_logger",
+    "dep:serde_json",
+    "dep:dotenvy",
 ]
 
 
@@ -122,3 +122,6 @@ env = "dev"
 #
 # Optional: Defaults to false. Can also be set with the LEPTOS_HASH_FILES=false env var
 hash-files = true
+
+server-fn-prefix = "/custom/prefix"
+disable-server-fn-hash = true

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -30,3 +30,4 @@ style-file = "project1/css/main.scss"
 site-root = "target/site/project1"
 server-fn-prefix = "/custom/prefix"
 disable-server-fn-hash = true
+server-fn-mod-path = true

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -28,3 +28,5 @@ lib-package = "front-package"
 assets-dir = "project1/assets"
 style-file = "project1/css/main.scss"
 site-root = "target/site/project1"
+server-fn-prefix = "/custom/prefix"
+disable-server-fn-hash = true

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -59,7 +59,9 @@ fn test_project_dev() {
     LEPTOS_JS_MINIFY=false \
     LEPTOS_HASH_FILES=true \
     LEPTOS_HASH_FILE_NAME=hash.txt \
-    LEPTOS_WATCH=true";
+    LEPTOS_WATCH=true \
+    SERVER_FN_PREFIX=/custom/prefix \
+    DISABLE_SERVER_FN_HASH=true";
     assert_eq!(ENV_REF, envs);
 
     assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
@@ -107,7 +109,9 @@ fn test_workspace_project1() {
     LEPTOS_BIN_DIR=project1\\server \
     LEPTOS_JS_MINIFY=false \
     LEPTOS_HASH_FILES=false \
-    LEPTOS_WATCH=true"
+    LEPTOS_WATCH=true \
+    SERVER_FN_PREFIX=/custom/prefix \
+    DISABLE_SERVER_FN_HASH=true"
     } else {
         "\
     LEPTOS_OUTPUT_NAME=project1 \
@@ -119,7 +123,9 @@ fn test_workspace_project1() {
     LEPTOS_BIN_DIR=project1/server \
     LEPTOS_JS_MINIFY=false \
     LEPTOS_HASH_FILES=false \
-    LEPTOS_WATCH=true"
+    LEPTOS_WATCH=true \
+    SERVER_FN_PREFIX=/custom/prefix \
+    DISABLE_SERVER_FN_HASH=true"
     };
 
     let cli = dev_opts();

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -61,7 +61,8 @@ fn test_project_dev() {
     LEPTOS_HASH_FILE_NAME=hash.txt \
     LEPTOS_WATCH=true \
     SERVER_FN_PREFIX=/custom/prefix \
-    DISABLE_SERVER_FN_HASH=true";
+    DISABLE_SERVER_FN_HASH=true \
+    SERVER_FN_MOD_PATH=true";
     assert_eq!(ENV_REF, envs);
 
     assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
@@ -111,7 +112,8 @@ fn test_workspace_project1() {
     LEPTOS_HASH_FILES=false \
     LEPTOS_WATCH=true \
     SERVER_FN_PREFIX=/custom/prefix \
-    DISABLE_SERVER_FN_HASH=true"
+    DISABLE_SERVER_FN_HASH=true \
+    SERVER_FN_MOD_PATH=true"
     } else {
         "\
     LEPTOS_OUTPUT_NAME=project1 \
@@ -125,7 +127,8 @@ fn test_workspace_project1() {
     LEPTOS_HASH_FILES=false \
     LEPTOS_WATCH=true \
     SERVER_FN_PREFIX=/custom/prefix \
-    DISABLE_SERVER_FN_HASH=true"
+    DISABLE_SERVER_FN_HASH=true \
+    SERVER_FN_MOD_PATH=true"
     };
 
     let cli = dev_opts();

--- a/src/config/dotenvs.rs
+++ b/src/config/dotenvs.rs
@@ -55,6 +55,8 @@ fn overlay(conf: &mut ProjectConfig, envs: impl Iterator<Item = (String, String)
             "LEPTOS_BIN_TARGET_DIR" => conf.bin_target_dir = Some(val),
             "LEPTOS_BIN_CARGO_COMMAND" => conf.bin_cargo_command = Some(val),
             "LEPTOS_JS_MINIFY" => conf.js_minify = val.parse()?,
+            "SERVER_FN_PREFIX" => conf.server_fn_prefix = Some(val),
+            "DISABLE_SERVER_FN_HASH" => conf.disable_server_fn_hash = true,
             // put these here to suppress the warning, but there's no
             // good way at the moment to pull the ProjectConfig all the way to Exe
             exe::ENV_VAR_LEPTOS_TAILWIND_VERSION => {}

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -49,6 +49,7 @@ pub struct Project {
     pub js_minify: bool,
     pub server_fn_prefix: Option<String>,
     pub disable_server_fn_hash: bool,
+    pub server_fn_mod_path: bool,
 }
 
 impl Debug for Project {
@@ -68,6 +69,7 @@ impl Debug for Project {
             .field("assets", &self.assets)
             .field("server_fn_prefix", &self.server_fn_prefix)
             .field("disable_server_fn_hash", &self.disable_server_fn_hash)
+            .field("server_fn_mod_path", &self.server_fn_mod_path)
             .finish_non_exhaustive()
     }
 }
@@ -132,6 +134,7 @@ impl Project {
                 js_minify: cli.release && cli.js_minify && config.js_minify,
                 server_fn_prefix: config.server_fn_prefix,
                 disable_server_fn_hash: config.disable_server_fn_hash,
+                server_fn_mod_path: config.server_fn_mod_path,
             };
             resolved.push(Arc::new(proj));
         }
@@ -172,6 +175,9 @@ impl Project {
         }
         if self.disable_server_fn_hash {
             vec.push(("DISABLE_SERVER_FN_HASH", true.to_string()));
+        }
+        if self.server_fn_mod_path {
+            vec.push(("SERVER_FN_MOD_PATH", true.to_string()));
         }
         vec
     }
@@ -257,6 +263,15 @@ pub struct ProjectConfig {
     /// path needs to be consistent and not have a hash appended.
     #[serde(default)]
     pub disable_server_fn_hash: bool,
+
+    /// Include the module path of the server function in the API route. This is an alternative
+    /// strategy to prevent duplicate server function API routes (the default strategy is to add
+    /// a hash to the end of the route). Each element of the module path will be separated by a `/`.
+    /// For example, a server function with a fully qualified name of `parent::child::server_fn`
+    /// would have an API route of `/api/parent/child/server_fn` (possibly with a
+    /// different prefix and a hash suffix depending on the values of the other server fn configs).
+    #[serde(default)]
+    server_fn_mod_path: bool,
 
     #[serde(skip)]
     pub config_dir: Utf8PathBuf,

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -1,6 +1,7 @@
 ---
 source: src/config/tests.rs
 expression: conf
+snapshot_kind: text
 ---
 Config {
     projects: [
@@ -71,6 +72,10 @@ Config {
                     dir: "project1/assets",
                 },
             ),
+            server_fn_prefix: Some(
+                "/custom/prefix",
+            ),
+            disable_server_fn_hash: true,
             ..
         },
         Project {
@@ -144,6 +149,8 @@ Config {
                     dir: "project2/src/assets",
                 },
             ),
+            server_fn_prefix: None,
+            disable_server_fn_hash: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -76,6 +76,7 @@ Config {
                 "/custom/prefix",
             ),
             disable_server_fn_hash: true,
+            server_fn_mod_path: true,
             ..
         },
         Project {
@@ -151,6 +152,7 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            server_fn_mod_path: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/config/tests.rs
 expression: conf
+snapshot_kind: text
 ---
 Config {
     projects: [
@@ -80,6 +81,8 @@ Config {
                     dir: "project2/src/assets",
                 },
             ),
+            server_fn_prefix: None,
+            disable_server_fn_hash: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -83,6 +83,7 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            server_fn_mod_path: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -78,6 +78,7 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            server_fn_mod_path: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/config/tests.rs
 expression: conf
+snapshot_kind: text
 ---
 Config {
     projects: [
@@ -75,6 +76,8 @@ Config {
                     dir: "project2/src/assets",
                 },
             ),
+            server_fn_prefix: None,
+            disable_server_fn_hash: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -76,6 +76,7 @@ Config {
                 "/custom/prefix",
             ),
             disable_server_fn_hash: true,
+            server_fn_mod_path: true,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -1,6 +1,7 @@
 ---
 source: src/config/tests.rs
 expression: conf
+snapshot_kind: text
 ---
 Config {
     projects: [
@@ -71,6 +72,10 @@ Config {
                     dir: "project1/assets",
                 },
             ),
+            server_fn_prefix: Some(
+                "/custom/prefix",
+            ),
+            disable_server_fn_hash: true,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -78,6 +78,7 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            server_fn_mod_path: false,
             ..
         },
     ],

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/config/tests.rs
 expression: conf
+snapshot_kind: text
 ---
 Config {
     projects: [
@@ -75,6 +76,8 @@ Config {
                     dir: "project2/src/assets",
                 },
             ),
+            server_fn_prefix: None,
+            disable_server_fn_hash: false,
             ..
         },
     ],


### PR DESCRIPTION
Add support to configure and set the `SERVER_FN_PREFIX`, `DISABLE_SERVER_FN_HASH`, and `SERVER_FN_MOD_PATH` env vars using the leptos project config.

See the following PR for more info: https://github.com/leptos-rs/leptos/pull/3438