### PR TITLE
Pin swc_ecma_ast to 5.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ async-trait = "0.1.83"
 md-5 = "0.10.6"
 base64ct = { version = "1.6.0", features = ["alloc"] }
 swc = "9.0"
+swc_ecma_ast = "=5.0.1"
 swc_common = "5.0"
 shlex = "1.3.0"
 


### PR DESCRIPTION
Fixes: https://github.com/leptos-rs/cargo-leptos/issues/419

Not the prettiest fix, but cargo install is not using Cargo.lock, so we need to pin swc_ecma_ast in Cargo.toml instead