### PR TITLE
Remove dep on ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,15 +104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,7 +451,6 @@ dependencies = [
 name = "cargo-leptos"
 version = "0.2.27"
 dependencies = [
- "ansi_term",
  "anyhow",
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -51,7 +51,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "serde",
  "version_check",
@@ -183,18 +183,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 dependencies = [
  "allocator-api2",
 ]
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
 dependencies = [
  "shlex",
 ]
@@ -580,7 +580,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -733,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -757,7 +757,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -823,7 +823,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -834,7 +834,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -855,7 +855,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -865,7 +865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "unicode-xid",
 ]
 
@@ -928,7 +928,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1068,7 +1068,7 @@ checksum = "8d7ccf961415e7aa17ef93dcb6c2441faaa8e768abe09e659b908089546f74c5"
 dependencies = [
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1155,8 +1155,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1225,9 +1237,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hstr"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d6824358c0fd9a68bb23999ed2ef76c84f79408a26ef7ae53d5f370c94ad36"
+checksum = "a1a26def229ea95a8709dad32868d975d0dd40235bd2ce82920e4a8fe692b5e0"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -1273,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -1285,9 +1297,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1478,7 +1490,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1566,13 +1578,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+checksum = "71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86"
 dependencies = [
  "console",
  "linked-hash-map",
  "once_cell",
+ "pin-project",
  "serde",
  "similar",
 ]
@@ -1601,7 +1614,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1687,9 +1700,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07eb295ad2f3b2af190da62af339b84fd01ce3c71702f09eb69a57310fcf0c6d"
+checksum = "8ba37d76693fc6228554e0bb06a9aa41c59e2b5180caf423c7913557b81d01dd"
 dependencies = [
  "anyhow",
  "camino",
@@ -1699,7 +1712,7 @@ dependencies = [
  "quote",
  "rstml",
  "serde",
- "syn 2.0.96",
+ "syn 2.0.98",
  "walkdir",
 ]
 
@@ -1758,7 +1771,7 @@ dependencies = [
  "cssparser-color",
  "dashmap",
  "data-encoding",
- "getrandom",
+ "getrandom 0.2.15",
  "indexmap 2.7.1",
  "itertools 0.10.5",
  "lazy_static",
@@ -1863,9 +1876,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
  "cfg-if",
  "miette-derive",
@@ -1877,13 +1890,13 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1915,7 +1928,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2189,7 +2202,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2199,6 +2212,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher 1.0.1",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2284,7 +2317,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "version_check",
  "yansi",
 ]
@@ -2335,7 +2368,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2363,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.15",
  "rand",
  "ring",
  "rustc-hash 2.1.0",
@@ -2438,7 +2471,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2476,7 +2509,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -2571,7 +2604,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -2623,7 +2656,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "syn_derive",
  "thiserror 2.0.11",
 ]
@@ -2670,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "once_cell",
  "ring",
@@ -2693,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -2719,9 +2752,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "ryu-js"
@@ -2797,14 +2830,14 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -2997,7 +3030,7 @@ checksum = "710e9696ef338691287aeb937ee6ffe60022f579d3c8d2fd9d58973a9a10a466"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3015,7 +3048,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3095,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec403702d532412d862e4a4ec0619022f05996a64876febe8ae5519146bdf0ce"
+checksum = "31cf812d2f10fd40a9c11227fe0e2e09779113f6ae6f04bd396ac5da92b69c91"
 dependencies = [
  "hstr",
  "once_cell",
@@ -3121,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a521e8120dc0401580864a643b5bffa035c29fc3fc41697c972743d4f008ed22"
+checksum = "29e67f0a373efdcbc1faebbb9ed7eaf7bcd7bc407cdd8b0fdd9475337c4364ce"
 dependencies = [
  "ahash 0.8.11",
  "ast_node",
@@ -3198,14 +3231,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "5.0.3"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05e7518b3052102506969009cabb027a88259ccde64ed675aa4ea8703b651f5"
+checksum = "f04d44a7edb591a66b9abc276ef306ab6d73d4ef189c1cb54423625ad236348f"
 dependencies = [
  "bitflags 2.8.0",
  "is-macro",
@@ -3249,7 +3282,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3689,7 +3722,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3865,7 +3898,7 @@ checksum = "e96e15288bf385ab85eb83cff7f9e2d834348da58d0a31b33bdb572e66ee413e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3901,7 +3934,7 @@ checksum = "a509f56fca05b39ba6c15f3e58636c3924c78347d63853632ed2ffcb6f5a0ac7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3917,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "swc_parallel"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22c97eeb6cad7e98dd246769b740e7f724fee6dc752190f14ad2b361cbf565b"
+checksum = "e5f75f1094d69174ef628e3665fff0f81d58e9f568802e3c90d332c72b0b6026"
 dependencies = [
  "once_cell",
 ]
@@ -3941,7 +3974,7 @@ checksum = "4c78717a841565df57f811376a3d19c9156091c55175e12d378f3a522de70cef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3996,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4014,7 +4047,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4034,7 +4067,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4062,13 +4095,13 @@ checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4110,7 +4143,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4121,7 +4154,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4175,7 +4208,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4248,7 +4281,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4320,9 +4353,9 @@ checksum = "2f322b60f6b9736017344fa0635d64be2f458fbc04eef65f6be22976dd1ffd5b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4443,7 +4476,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4460,6 +4493,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4483,7 +4525,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -4551,7 +4593,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4657,9 +4699,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4901,6 +4943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4958,7 +5009,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -4980,7 +5031,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5000,7 +5051,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -5029,7 +5080,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ which = "7"
 cargo_metadata = { version = "0.19", features = ["builder"] }
 serde_json = "1.0.128"
 wasm-bindgen-cli-support = "0.2.100"
-ansi_term = "0.12"
 
 reqwest = { version = "0.12.8", features = [
   "blocking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ eula = false
 
 [dependencies]
 brotli = "7"
-clap = { version = "4.5.18", features = ["derive"] }
+clap = { version = "4.5.27", features = ["derive"] }
 serde = { version = "1.0.210", features = ["derive"] }
 anyhow = "1.0.89"
 libflate = "2"

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -1,6 +1,7 @@
 use crate::compile::{front_cargo_process, server_cargo_process};
 use crate::config::{Config, Project};
 use crate::ext::anyhow::{anyhow, Context, Result};
+use crate::ext::Paint;
 use crate::logger::GRAY;
 
 pub async fn test_all(conf: &Config) -> Result<()> {

--- a/src/compile/assets.rs
+++ b/src/compile/assets.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use super::ChangeSet;
 use crate::config::Project;
 use crate::ext::anyhow::{Context, Result};
+use crate::ext::Paint;
 use crate::signal::{Outcome, Product};
 use crate::{ext::PathExt, fs, logger::GRAY};
 use camino::{Utf8Path, Utf8PathBuf};

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -7,6 +7,7 @@ use crate::{
     ext::{
         anyhow::{Context, Result},
         exe::Exe,
+        Paint,
     },
     logger::GRAY,
 };

--- a/src/compile/sass.rs
+++ b/src/compile/sass.rs
@@ -2,6 +2,7 @@ use crate::{
     ext::{
         anyhow::{Context, Result},
         sync::{wait_piped_interruptible, CommandResult, OutputExt},
+        Paint,
     },
     logger::GRAY,
     signal::{Interrupt, Outcome},

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 use super::ChangeSet;
 use crate::{
     config::Project,
-    ext::anyhow::{Context, Result},
-    ext::sync::{wait_interruptible, CommandResult},
+    ext::{
+        anyhow::{Context, Result},
+        sync::{wait_interruptible, CommandResult},
+        Paint,
+    },
     logger::GRAY,
     signal::{Interrupt, Outcome, Product},
 };

--- a/src/compile/style.rs
+++ b/src/compile/style.rs
@@ -4,7 +4,7 @@ use crate::{
     config::Project,
     ext::{
         anyhow::{anyhow, bail, Context, Result},
-        PathBufExt,
+        Paint, PathBufExt,
     },
     fs,
     logger::GRAY,

--- a/src/compile/tailwind.rs
+++ b/src/compile/tailwind.rs
@@ -7,7 +7,7 @@ use crate::{
         anyhow::Context,
         fs,
         sync::{wait_piped_interruptible, CommandResult, OutputExt},
-        Exe,
+        Exe, Paint,
     },
     logger::GRAY,
     signal::{Interrupt, Outcome},

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -1,4 +1,5 @@
 use crate::config::hash_file::HashFile;
+use crate::ext::Paint;
 use crate::{
     config::lib_package::LibPackage,
     ext::{

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -1,5 +1,8 @@
 use crate::{
-    ext::anyhow::{bail, Context, Result},
+    ext::{
+        anyhow::{bail, Context, Result},
+        Paint,
+    },
     logger::GRAY,
 };
 use bytes::Bytes;

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -15,4 +15,4 @@ pub use exe::{Exe, ExeMeta};
 pub use path::{
     append_str_to_filename, determine_pdb_filename, remove_nested, PathBufExt, PathExt,
 };
-pub use util::{os_arch, StrAdditions};
+pub use util::{os_arch, Paint, StrAdditions};

--- a/src/ext/util.rs
+++ b/src/ext/util.rs
@@ -1,5 +1,6 @@
 use crate::ext::anyhow::{bail, Context, Result};
 use camino::Utf8PathBuf;
+use clap::builder::styling::{Color, Style};
 use std::borrow::Cow;
 
 pub fn os_arch() -> Result<(&'static str, &'static str)> {
@@ -72,5 +73,18 @@ impl StrAdditions for String {
 
     fn to_created_dir(&self) -> Result<Utf8PathBuf> {
         self.as_str().to_created_dir()
+    }
+}
+
+pub trait Paint {
+    fn paint<'a>(self, text: impl Into<Cow<'a, str>>) -> String;
+}
+
+impl Paint for Color {
+    fn paint<'a>(self, text: impl Into<Cow<'a, str>>) -> String {
+        let text = text.into();
+        let style = Style::new().fg_color(Some(self));
+
+        format!("{style}{text}{style:#}")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::ext::PathBufExt;
 use crate::logger::GRAY;
 use camino::Utf8PathBuf;
 use config::{Cli, Config};
-use ext::fs;
+use ext::{fs, Paint};
 use signal::Interrupt;
 use std::env;
 use std::path::PathBuf;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -15,7 +15,7 @@ const fn color(num: u8) -> Color {
 
 const ERR_RED: Color = color(196);
 const WARN_YELLOW: Color = color(214);
-pub const INFO_GREEN: Color = color(77);
+const INFO_GREEN: Color = color(77);
 const DBG_BLUE: Color = color(26);
 const TRACE_VIOLET: Color = color(98);
 pub const GRAY: Color = color(241);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use ansi_term::{Colour::Fixed, Style};
+use clap::builder::styling::{Ansi256Color, Color};
 use flexi_logger::{
     filter::{LogLineFilter, LogLineWriter},
     DeferredNow, Level, Record,
@@ -6,21 +6,21 @@ use flexi_logger::{
 use std::io::Write;
 use std::sync::OnceLock;
 
-use crate::ext::anyhow::Context;
+use crate::ext::{anyhow::Context, Paint};
 use crate::{config::Log, ext::StrAdditions};
 
-// https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
-lazy_static::lazy_static! {
-   static ref ERR_RED: ansi_term::Color = Fixed(196);
-   static ref WARN_YELLOW: ansi_term::Color = Fixed(214);
-   pub static ref INFO_GREEN: ansi_term::Color = Fixed(77);
-   static ref DBG_BLUE: ansi_term::Color = Fixed(26);
-   static ref TRACE_VIOLET: ansi_term::Color = Fixed(98);
-
-   pub static ref GRAY: ansi_term::Color = Fixed(241);
-   pub static ref BOLD: ansi_term::Style = Style::new().bold();
-   static ref LOG_SELECT: OnceLock<LogFlag> = OnceLock::new();
+const fn color(num: u8) -> Color {
+    Color::Ansi256(Ansi256Color(num))
 }
+
+const ERR_RED: Color = color(196);
+const WARN_YELLOW: Color = color(214);
+pub const INFO_GREEN: Color = color(77);
+const DBG_BLUE: Color = color(26);
+const TRACE_VIOLET: Color = color(98);
+pub const GRAY: Color = color(241);
+
+static LOG_SELECT: OnceLock<LogFlag> = OnceLock::new();
 
 pub fn setup(verbose: u8, logs: &[Log]) {
     let log_level = match verbose {
@@ -94,7 +94,7 @@ fn format(
     } else {
         let (word, rest) = split(&args);
         let word = word.pad_left_to(12);
-        write!(write, "{} {}", lvl_color.paint(word), rest)
+        write!(write, "{} {rest}", lvl_color.paint(word))
     }
 }
 
@@ -136,17 +136,17 @@ impl LogLineFilter for Filter {
 }
 
 trait LevelExt {
-    fn color(&self) -> ansi_term::Color;
+    fn color(&self) -> Color;
 }
 
 impl LevelExt for Level {
-    fn color(&self) -> ansi_term::Color {
+    fn color(&self) -> Color {
         match self {
-            Level::Error => *ERR_RED,
-            Level::Warn => *WARN_YELLOW,
-            Level::Info => *INFO_GREEN,
-            Level::Debug => *DBG_BLUE,
-            Level::Trace => *TRACE_VIOLET,
+            Level::Error => ERR_RED,
+            Level::Warn => WARN_YELLOW,
+            Level::Info => INFO_GREEN,
+            Level::Debug => DBG_BLUE,
+            Level::Trace => TRACE_VIOLET,
         }
     }
 }

--- a/src/service/notify.rs
+++ b/src/service/notify.rs
@@ -1,6 +1,7 @@
 use crate::compile::Change;
 use crate::config::Project;
 use crate::ext::anyhow::{anyhow, Result};
+use crate::ext::Paint;
 use crate::signal::Interrupt;
 use crate::{
     ext::{remove_nested, PathBufExt, PathExt},
@@ -117,7 +118,7 @@ fn handle(event: Event, proj: Arc<Project>) {
     for path in paths {
         if let Some(assets) = &proj.assets {
             if path.starts_with(&assets.dir) {
-                log::debug!("Notify asset change {}", GRAY.paint(path.to_string()));
+                log::debug!("Notify asset change {}", GRAY.paint(path.as_str()));
                 changes.push(Change::Asset);
             }
         }
@@ -126,19 +127,19 @@ fn handle(event: Event, proj: Arc<Project>) {
         let lib_js = path.starts_with(&proj.js_dir) && path.is_ext_any(&["js"]);
 
         if lib_rs || lib_js {
-            log::debug!("Notify lib source change {}", GRAY.paint(path.to_string()));
+            log::debug!("Notify lib source change {}", GRAY.paint(path.as_str()));
             changes.push(Change::LibSource);
         }
 
         if path.starts_with_any(&proj.bin.src_paths) && path.is_ext_any(&["rs"]) {
-            log::debug!("Notify bin source change {}", GRAY.paint(path.to_string()));
+            log::debug!("Notify bin source change {}", GRAY.paint(path.as_str()));
             changes.push(Change::BinSource);
         }
 
         if let Some(file) = &proj.style.file {
             let src = file.source.clone().without_last();
             if path.starts_with(src) && path.is_ext_any(&["scss", "sass", "css"]) {
-                log::debug!("Notify style change {}", GRAY.paint(path.to_string()));
+                log::debug!("Notify style change {}", GRAY.paint(path.as_str()));
                 changes.push(Change::Style)
             }
         }
@@ -147,7 +148,7 @@ fn handle(event: Event, proj: Arc<Project>) {
             if path.as_path() == tailwind.config_file.as_path()
                 || path.as_path() == tailwind.input_file.as_path()
             {
-                log::debug!("Notify style change {}", GRAY.paint(path.to_string()));
+                log::debug!("Notify style change {}", GRAY.paint(path.as_str()));
                 changes.push(Change::Style)
             }
         }
@@ -155,7 +156,7 @@ fn handle(event: Event, proj: Arc<Project>) {
         if path.starts_with_any(&proj.watch_additional_files) {
             log::debug!(
                 "Notify additional file change {}",
-                GRAY.paint(path.to_string())
+                GRAY.paint(path.as_str())
             );
             changes.push(Change::Additional);
         }
@@ -165,7 +166,7 @@ fn handle(event: Event, proj: Arc<Project>) {
         } else {
             log::trace!(
                 "Notify changed but not watched: {}",
-                GRAY.paint(path.to_string())
+                GRAY.paint(path.as_str())
             );
         }
     }

--- a/src/service/patch.rs
+++ b/src/service/patch.rs
@@ -1,6 +1,6 @@
 use crate::config::Project;
 use crate::ext::anyhow::Result;
-use crate::ext::PathBufExt;
+use crate::ext::{Paint, PathBufExt};
 use crate::signal::{Interrupt, ReloadSignal};
 use crate::{ext::remove_nested, logger::GRAY};
 use camino::Utf8PathBuf;

--- a/src/service/reload.rs
+++ b/src/service/reload.rs
@@ -1,5 +1,6 @@
 use crate::config::Project;
 use crate::ext::sync::wait_for_socket;
+use crate::ext::Paint;
 use crate::logger::GRAY;
 use crate::signal::Interrupt;
 use crate::signal::{ReloadSignal, ReloadType};

--- a/src/service/serve.rs
+++ b/src/service/serve.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     config::Project,
-    ext::{anyhow::Result, append_str_to_filename, determine_pdb_filename, fs},
+    ext::{anyhow::Result, append_str_to_filename, determine_pdb_filename, fs, Paint},
     logger::GRAY,
     signal::{Interrupt, ReloadSignal, ServerRestart},
 };


### PR DESCRIPTION
Running `cargo-audit` on this repo revealed that it depends directly on an unmaintained dependency: `ansi_term`. This PR removes that dependency. Fortunately, it just so happens that `clap`—which `cargo-leptos` already depends on—supports everything `cargo-leptos` was using `ansi_term` to do.