### PR TITLE
fix: catch `any` event in case the OS isn't specific about the event.

### DIFF
--- a/src/service/notify.rs
+++ b/src/service/notify.rs
@@ -92,8 +92,7 @@ fn handle(event: Event, proj: Arc<Project>) {
     if let EventKind::Any
     | EventKind::Other
     | EventKind::Access(_)
-    | EventKind::Modify(ModifyKind::Any | ModifyKind::Other | ModifyKind::Metadata(_)) =
-        event.kind
+    | EventKind::Modify(ModifyKind::Other | ModifyKind::Metadata(_)) = event.kind
     {
         return;
     };


### PR DESCRIPTION
Windows isn't specific about the notify event.
Closes: #430