### PR TITLE
refactor: Moved logging init into main.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod command;
 pub mod compile;
 pub mod config;
 pub mod ext;
-mod logger;
+pub mod logger;
 pub mod service;
 pub mod signal;
 
@@ -21,9 +21,6 @@ use std::env;
 use std::path::PathBuf;
 
 pub async fn run(args: Cli) -> Result<()> {
-    let verbose = args.opts().map(|o| o.verbose).unwrap_or(0);
-    logger::setup(verbose, &args.log);
-
     if let New(new) = &args.command {
         return new.run().await;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,5 +12,9 @@ async fn main() -> Result<()> {
     }
 
     let args = Cli::parse_from(&args);
+
+    let verbose = args.opts().map(|o| o.verbose).unwrap_or(0);
+    cargo_leptos::logger::setup(verbose, &args.log);
+
     run(args).await
 }


### PR DESCRIPTION
This allows me to link against the library without `panic`ing on twice initialised logging (I'm using tracing)