### PR TITLE
fix(watch): add debounce to notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
  "lightningcss",
  "log",
  "md-5",
- "notify",
+ "notify-debouncer-full",
  "pathdiff",
  "reqwest",
  "seahash",
@@ -1325,6 +1325,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "file-id"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "filetime"
@@ -2813,6 +2822,19 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d88b1a7538054351c8258338df7c931a590513fb3745e8c15eb9ff4199b8d1"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ flexi_logger = "0.29.8"
 tokio = { version = "1.43.0", default-features = false, features = ["full"] }
 axum = { version = "0.8.1", features = ["ws"] }
 # not using notify 5.0 because it uses Crossbeam which has an issue with tokio
-notify = "8.0"
+notify-debouncer-full = "0.5.0"
 lazy_static = "1.5"
 which = "7"
 cargo_metadata = { version = "0.19", features = ["builder"] }

--- a/src/compile/change.rs
+++ b/src/compile/change.rs
@@ -1,4 +1,4 @@
-use std::vec;
+use std::{ops::Deref, vec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Change {
@@ -20,6 +20,10 @@ pub enum Change {
 pub struct ChangeSet(Vec<Change>);
 
 impl ChangeSet {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
     pub fn all_changes() -> Self {
         Self(vec![
             Change::BinSource,
@@ -66,5 +70,13 @@ impl ChangeSet {
         } else {
             false
         }
+    }
+}
+
+impl Deref for ChangeSet {
+    type Target = Vec<Change>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }


### PR DESCRIPTION
This PR does:
- aggregates the change events from notify (every 100 ms) and then tries to send appropriate signals to build loops.
- prevents overloading the interrupt-based cycle, especially while modifying multiple files.
- makes the event loop more efficient.