### PR TITLE
fix: warn on watch with --release and --hot-reload

### DIFF
--- a/src/command/watch.rs
+++ b/src/command/watch.rs
@@ -21,6 +21,10 @@ pub async fn watch(proj: &Arc<Project>) -> Result<()> {
         return Ok(());
     }
 
+    if proj.hot_reload && proj.release {
+        log::warn!("warning: Hot reloading does not currently work in --release mode.");
+    }
+
     let view_macros = if proj.hot_reload {
         // build initial set of view macros for patching
         let view_macros = ViewMacros::new();


### PR DESCRIPTION
Due to the cfg(debug_assertions) line here:
https://github.com/leptos-rs/leptos/blob/7c34b4a4a5daeb6bd340b0ccb684e9d2f616f306/leptos/src/into_view.rs#L110

Hot reloading does not work if you pass --release, as debug_assertions is off in release mode. This results in the relevant element tagging being missing from the HTML document and the hot reload node walker not walking any nodes.

This commit simply warns if a user passes --release and --hot-reload together to leptos watch to save time when a user encounters this issue.

I've put the text "warning:" before as it seems in this context the warning message is printed such that the first word is colorized, and without the text "warning:"