### PR TITLE
Fix (some) cargo dist releases

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -1,0 +1,10 @@
+- name: Install MUSL tools and configure environment
+  env:
+    TARGETS: ${{ join(matrix.targets, '-') }}
+  if: contains(env.TARGETS, 'x86_64-unknown-linux-musl')
+  run: |
+    sudo apt-get update
+    sudo apt-get install -y musl-tools musl-dev build-essential pkg-config libssl-dev
+    if ! command -v musl-g++ > /dev/null; then
+      sudo ln -s $(which musl-gcc) /usr/local/bin/musl-g++
+    fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,13 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Symlink g++ compiler for musl targets"
+        if: "contains(env.TARGETS, 'x86_64-unknown-linux-musl')"
+        run: |
+          sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
+          ls -l /usr/bin/musl-g++
+        env:
+          "TARGETS": "${{ join(matrix.targets, '-') }}"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,14 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - name: "Symlink g++ compiler for musl targets"
+      - name: "Install MUSL tools and configure environment"
         if: "contains(env.TARGETS, 'x86_64-unknown-linux-musl')"
         run: |
-          sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
-          ls -l /usr/bin/musl-g++
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev build-essential pkg-config libssl-dev
+          if ! command -v musl-g++ > /dev/null; then
+            sudo ln -s $(which musl-gcc) /usr/local/bin/musl-g++
+          fi
         env:
           "TARGETS": "${{ join(matrix.targets, '-') }}"
       - name: Install dist

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -23,3 +23,5 @@ hosting = ["axodotdev", "github"]
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# Add custom build setup steps
+github-build-setup = "../build-setup.yml"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Which actions to run on pull requests
@@ -18,7 +18,7 @@ windows-archive = ".tar.gz"
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # Where to host releases
-hosting = ["axodotdev", "github"]
+hosting = "github"
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Which actions to run on pull requests
@@ -18,7 +18,7 @@ windows-archive = ".tar.gz"
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # Where to host releases
-hosting = "github"
+hosting = ["axodotdev", "github"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
### Problem
All `aarch64` builds and the `musl` build are [currently failing](https://github.com/leptos-rs/cargo-leptos/actions/runs/13457858276) in our `cargo-dist` setup.

### Changes in this PR
First, I saw that `cargo-dist` is `dist` now and moved the configuration out of `Cargo.toml` into `dist-workflow.toml`, so I followed their recommendation.

Looking at the build logs, we see that the `aarch64` builds are complaining about not finding the OpenSSL installation. So I added a vendored OpenSSL, which fixes the Darwin and Linux builds. 

The `aarch64` Windows build, however, fails while trying to compile `psm v0.1.25`, which [does not support Windows](https://github.com/rust-lang/stacker/issues/99#issuecomment-2404989304).

`x86_64-unknown-linux-musl` fails because it cannot find `musl-g++`. `musl` does not package a C++ compiler. I tried the [ugly fix of symlinking another g++ to musl-g++](https://github.com/rust-lang/cargo/issues/3359#issuecomment-325614445) but then it fails later because it cannot find some fortified functions while linking. I guess one has to manually compile a C++ compiler targetting `musl`.

### Conclusion
I would suggest disabling the `aarch64-pc-windows-msvc` and `x86_64-unknown-linux-musl` builds for now in cargo dist.