### PR TITLE
add: Cli.opts_mut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-leptos"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -97,6 +97,7 @@ pub fn build_cargo_front_cmd(
 
     command.args(&args).envs(envs);
     let line = super::build_cargo_command_string(args);
+    trace!(?envs_str, ?line, "Constructed cargo build front cmd");
     (envs_str, line)
 }
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -87,18 +87,28 @@ pub struct Cli {
 
 impl Cli {
     pub fn opts(&self) -> Option<Opts> {
-        use Commands::{Build, EndToEnd, New, Serve, Test, Watch};
         match &self.command {
-            New(_) => None,
-            Serve(bin_opts) | Watch(bin_opts) => Some(bin_opts.opts.clone()),
-            Build(opts) | Test(opts) | EndToEnd(opts) => Some(opts.clone()),
+            Commands::New(_) => None,
+            Commands::Serve(bin_opts) | Commands::Watch(bin_opts) => Some(bin_opts.opts.clone()),
+            Commands::Build(opts) | Commands::Test(opts) | Commands::EndToEnd(opts) => {
+                Some(opts.clone())
+            }
+        }
+    }
+
+    pub fn opts_mut(&mut self) -> Option<&mut Opts> {
+        match &mut self.command {
+            Commands::New(_) => None,
+            Commands::Serve(bin_opts) | Commands::Watch(bin_opts) => Some(&mut bin_opts.opts),
+            Commands::Build(opts) | Commands::Test(opts) | Commands::EndToEnd(opts) => Some(opts),
         }
     }
 
     pub fn bin_args(&self) -> Option<&[String]> {
-        use Commands::{Serve, Watch};
         match &self.command {
-            Serve(bin_opts) | Watch(bin_opts) => Some(bin_opts.bin_args.as_ref()),
+            Commands::Serve(bin_opts) | Commands::Watch(bin_opts) => {
+                Some(bin_opts.bin_args.as_ref())
+            }
             _ => None,
         }
     }

--- a/src/ext/sync.rs
+++ b/src/ext/sync.rs
@@ -47,6 +47,7 @@ pub async fn wait_interruptible(
     mut process: Child,
     mut interrupt_rx: broadcast::Receiver<()>,
 ) -> Result<CommandResult<()>> {
+    trace!(?process, "Waiting for process to finish");
     tokio::select! {
         res = process.wait() => match res {
             Ok(exit) => {
@@ -73,6 +74,7 @@ pub async fn wait_piped_interruptible(
     mut cmd: Command,
     mut interrupt_rx: broadcast::Receiver<()>,
 ) -> Result<CommandResult<Output>> {
+    trace!(?cmd, "Waiting for command (piped)");
     // see: https://docs.rs/tokio/latest/tokio/process/index.html
 
     cmd.kill_on_drop(true);


### PR DESCRIPTION
This helps me write Rust-powered developer scripts to have fine-grained control over cargo-leptos