### PR TITLE
fix: use `which` to run `end2end_cmd`

### DIFF
--- a/src/command/end2end.rs
+++ b/src/command/end2end.rs
@@ -42,7 +42,7 @@ async fn try_run(cmd: &str, dir: &Utf8Path) -> Result<()> {
     let args = parts.collect::<Vec<_>>();
 
     trace!("End2End running {cmd:?}");
-    let mut process = Command::new(exe)
+    let mut process = Command::new(which::which(exe)?)
         .args(args)
         .current_dir(dir)
         .spawn()


### PR DESCRIPTION
Makes it behave like running the command in a shell would. Resolves #384