### PR TITLE
Enable erase-components flag for debug mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-leptos"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ bin-cargo-args = ["--timings"]
 #
 # Optional. No default. Env: LEPTOS_BIN_CARGO_COMMAND
 bin-cargo-command = "cross"
+
+# Whether to enable erased components mode for all cargo-leptos builds. This optimizes for compile speed,
+# at the cost of a runtime/binary size overhead per component.
+#
+# Optional. By default, erased components are used for debug builds, and not for release builds.
+always-erase-components = "false"
+
+# Whether to disable erased components mode for all cargo-leptos builds. 
+#
+# Optional. By default, erased components are used for debug builds, and not for release builds.
+disable-erase-components = "false"
 ```
 
 ## Site parameters

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -63,7 +63,7 @@ fn test_project_dev() {
     SERVER_FN_PREFIX=/custom/prefix \
     DISABLE_SERVER_FN_HASH=true \
     SERVER_FN_MOD_PATH=true \
-    RUSTFLAGS=\"--cfg erase_components\"";
+    RUSTFLAGS=--cfg erase_components";
     assert_eq!(ENV_REF, envs);
 
     assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
@@ -115,7 +115,7 @@ fn test_workspace_project1() {
     SERVER_FN_PREFIX=/custom/prefix \
     DISABLE_SERVER_FN_HASH=true \
     SERVER_FN_MOD_PATH=true \
-    RUSTFLAGS=\"--cfg erase_components\""
+    RUSTFLAGS=--cfg erase_components"
     } else {
         "\
     LEPTOS_OUTPUT_NAME=project1 \
@@ -131,7 +131,7 @@ fn test_workspace_project1() {
     SERVER_FN_PREFIX=/custom/prefix \
     DISABLE_SERVER_FN_HASH=true \
     SERVER_FN_MOD_PATH=true \
-    RUSTFLAGS=\"--cfg erase_components\""
+    RUSTFLAGS=--cfg erase_components"
     };
 
     let cli = dev_opts();

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -62,7 +62,8 @@ fn test_project_dev() {
     LEPTOS_WATCH=true \
     SERVER_FN_PREFIX=/custom/prefix \
     DISABLE_SERVER_FN_HASH=true \
-    SERVER_FN_MOD_PATH=true";
+    SERVER_FN_MOD_PATH=true \
+    RUSTFLAGS=\"--cfg erase_components\"";
     assert_eq!(ENV_REF, envs);
 
     assert_snapshot!(cargo, @"cargo build --package=example --bin=example --no-default-features --features=ssr");
@@ -113,7 +114,8 @@ fn test_workspace_project1() {
     LEPTOS_WATCH=true \
     SERVER_FN_PREFIX=/custom/prefix \
     DISABLE_SERVER_FN_HASH=true \
-    SERVER_FN_MOD_PATH=true"
+    SERVER_FN_MOD_PATH=true \
+    RUSTFLAGS=\"--cfg erase_components\""
     } else {
         "\
     LEPTOS_OUTPUT_NAME=project1 \
@@ -128,7 +130,8 @@ fn test_workspace_project1() {
     LEPTOS_WATCH=true \
     SERVER_FN_PREFIX=/custom/prefix \
     DISABLE_SERVER_FN_HASH=true \
-    SERVER_FN_MOD_PATH=true"
+    SERVER_FN_MOD_PATH=true \
+    RUSTFLAGS=\"--cfg erase_components\""
     };
 
     let cli = dev_opts();

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -190,8 +190,8 @@ impl Project {
 
         // Set the default to erase-components mode if in debug mode and not explicitly disabled
         // or always enabled
-        if (!self.disable_erase_components && !self.release) || (self.always_erase_components)  {
-            vec.push(("RUSTFLAGS", "--cfg erase_components".to_string()))
+        if (!self.disable_erase_components && !self.release) || (self.always_erase_components) {
+            vec.push(("RUSTFLAGS", "\"--cfg erase_components\"".to_string()))
         }
         vec
     }
@@ -277,7 +277,6 @@ pub struct ProjectConfig {
     /// path needs to be consistent and not have a hash appended.
     #[serde(default)]
     pub disable_server_fn_hash: bool,
-
 
     /// Whether to disable erased components mode for debug mode. Overridden by the the following
     /// cli flag `always_enable_erase_components`.

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -191,7 +191,7 @@ impl Project {
         // Set the default to erase-components mode if in debug mode and not explicitly disabled
         // or always enabled
         if (!self.disable_erase_components && !self.release) || (self.always_erase_components) {
-            vec.push(("RUSTFLAGS", "\"--cfg erase_components\"".to_string()))
+            vec.push(("RUSTFLAGS", "--cfg erase_components".to_string()))
         }
         vec
     }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -48,6 +48,8 @@ pub struct Project {
     pub js_minify: bool,
     pub server_fn_prefix: Option<String>,
     pub disable_server_fn_hash: bool,
+    pub disable_erase_components: bool,
+    pub always_erase_components: bool,
     pub server_fn_mod_path: bool,
 }
 
@@ -68,6 +70,8 @@ impl Debug for Project {
             .field("assets", &self.assets)
             .field("server_fn_prefix", &self.server_fn_prefix)
             .field("disable_server_fn_hash", &self.disable_server_fn_hash)
+            .field("disable_erase_components", &self.disable_erase_components)
+            .field("always_erase_components", &self.always_erase_components)
             .field("server_fn_mod_path", &self.server_fn_mod_path)
             .finish_non_exhaustive()
     }
@@ -133,6 +137,8 @@ impl Project {
                 js_minify: cli.release && (cli.js_minify || config.js_minify),
                 server_fn_prefix: config.server_fn_prefix,
                 disable_server_fn_hash: config.disable_server_fn_hash,
+                disable_erase_components: config.disable_erase_components,
+                always_erase_components: config.always_erase_components,
                 server_fn_mod_path: config.server_fn_mod_path,
             };
             resolved.push(Arc::new(proj));
@@ -180,6 +186,12 @@ impl Project {
         }
         if self.server_fn_mod_path {
             vec.push(("SERVER_FN_MOD_PATH", self.server_fn_mod_path.to_string()));
+        }
+
+        // Set the default to erase-components mode if in debug mode and not explicitly disabled
+        // or always enabled
+        if (!self.disable_erase_components && !self.release) || (self.always_erase_components)  {
+            vec.push(("RUSTFLAGS", "--cfg erase_components".to_string()))
         }
         vec
     }
@@ -266,6 +278,28 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub disable_server_fn_hash: bool,
 
+
+    /// Whether to disable erased components mode for debug mode. Overridden by the the following
+    /// cli flag `always_enable_erase_components`.
+    ///
+    /// erase_components mode offers a signifigant compile time speedup by type erasing the types
+    /// in your app. This is similar to adding `.into_any()` to your entire app. It can also solve
+    /// some issues with compilation in debug mode. It is automatically enabled in debug mode, but
+    /// can be disabled by setting this to true. If you'd like to use it for all profiles, see the
+    /// next flag, `always_enable_erase_components`
+    #[serde(default)]
+    pub disable_erase_components: bool,
+
+    /// Whether to enable erased components mode for all cargo-leptos builds. Overrides the cli
+    /// flag `disable_erase_components`.
+    ///
+    /// erase_components mode offers a signifigant compile time speedup by type erasing the types
+    /// in your app. This is similar to adding `.into_any()` to your entire app. It can also solve
+    /// some issues with compilation in debug mode. It is automatically enabled in debug mode, but
+    /// can be disabled by setting this to true. If you'd like to use it for all profiles, see the
+    /// next flag, `always_enable_erase_components`
+    #[serde(default)]
+    pub always_erase_components: bool,
     /// Include the module path of the server function in the API route. This is an alternative
     /// strategy to prevent duplicate server function API routes (the default strategy is to add
     /// a hash to the end of the route). Each element of the module path will be separated by a `/`.

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/tests.rs
 expression: conf
-snapshot_kind: text
 ---
 Config {
     projects: [
@@ -76,6 +75,8 @@ Config {
                 "/custom/prefix",
             ),
             disable_server_fn_hash: true,
+            disable_erase_components: false,
+            always_erase_components: false,
             server_fn_mod_path: true,
             ..
         },
@@ -152,6 +153,8 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            disable_erase_components: false,
+            always_erase_components: false,
             server_fn_mod_path: false,
             ..
         },

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/tests.rs
 expression: conf
-snapshot_kind: text
 ---
 Config {
     projects: [
@@ -83,6 +82,8 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            disable_erase_components: false,
+            always_erase_components: false,
             server_fn_mod_path: false,
             ..
         },

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/tests.rs
 expression: conf
-snapshot_kind: text
 ---
 Config {
     projects: [
@@ -78,6 +77,8 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            disable_erase_components: false,
+            always_erase_components: false,
             server_fn_mod_path: false,
             ..
         },

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/tests.rs
 expression: conf
-snapshot_kind: text
 ---
 Config {
     projects: [
@@ -76,6 +75,8 @@ Config {
                 "/custom/prefix",
             ),
             disable_server_fn_hash: true,
+            disable_erase_components: false,
+            always_erase_components: false,
             server_fn_mod_path: true,
             ..
         },

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/config/tests.rs
 expression: conf
-snapshot_kind: text
 ---
 Config {
     projects: [
@@ -78,6 +77,8 @@ Config {
             ),
             server_fn_prefix: None,
             disable_server_fn_hash: false,
+            disable_erase_components: false,
+            always_erase_components: false,
             server_fn_mod_path: false,
             ..
         },

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -1,5 +1,4 @@
 use crate::{config::VersionConfig, ext::Paint, internal_prelude::*, logger::GRAY};
-use anyhow::Context;
 use bytes::Bytes;
 use std::{
     borrow::Cow,


### PR DESCRIPTION
Enabling this flag by default will offer significant compile time decreases and resolve some issues with debug symbols in dev mode. Also includes the flags `disable_erase_components` to stop this behavior and `always_enable_erase_components` to do this for both debug and prod