### PR TITLE
remove unused import

### DIFF
--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -1,5 +1,4 @@
 use crate::{config::VersionConfig, ext::Paint, internal_prelude::*, logger::GRAY};
-use anyhow::Context;
 use bytes::Bytes;
 use std::{
     borrow::Cow,


### PR DESCRIPTION
I've seen this warning while working on #481 so I've decided to fix it while I have my editor open.