### PR TITLE
Fix Cargo.lock being out of sync with Cargo.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
             workspaces: |
               .
               examples/workspace
+        - name: "Check that lock file is up to date"
+          run: cargo fetch --locked
               
         - name: "Run cargo test --features=full_tests"
           uses: actions-rs/cargo@v1


### PR DESCRIPTION
The latest release includes an out of date Cargo.lock, which prevents building with `--locked`

This PR adds a `cargo fetch --locked` step in the CI to prevent this from happening again in the future

Clos