### PR TITLE
fix: respect env rustflags, closes #496

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-config2"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc3749a36e0423c991f1e7a3e4ab0c36a1f489658313db4b187d401d79cc461"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml_edit",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cargo-generate"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +558,7 @@ dependencies = [
  "brotli",
  "bytes",
  "camino",
+ "cargo-config2",
  "cargo-generate",
  "cargo_metadata",
  "clap",
@@ -574,6 +587,7 @@ dependencies = [
  "swc",
  "swc_common",
  "tar",
+ "target-lexicon",
  "temp-dir",
  "tokio",
  "tracing",
@@ -5435,6 +5449,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "temp-dir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ anyhow = "1.0.98"
 color-eyre = "0.6.3"
 libflate = "2"
 tracing = "0.1.41"
+cargo-config2 = "0.1.32"
+target-lexicon = "0.13.2"
 
 lightningcss = { version = "1.0.0-alpha.63", features = ["browserslist"] }
 flexi_logger = "0.30.1"
@@ -33,9 +35,9 @@ serde_json = "1.0.138"
 wasm-bindgen-cli-support = "0.2.100"
 
 reqwest = { version = "0.12.15", features = [
-    "blocking",
-    "rustls-tls",
-    "json",
+  "blocking",
+  "rustls-tls",
+  "json",
 ], default-features = false }
 seahash = "4.1"
 dirs = "6.0"

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -1,18 +1,26 @@
 use super::ChangeSet;
-use crate::config::Project;
-use crate::ext::sync::{wait_interruptible, CommandResult};
-use crate::ext::{fs, PathBufExt};
-use crate::internal_prelude::*;
-use crate::logger::GRAY;
-use crate::signal::{Interrupt, Outcome, Product};
+use crate::{
+    config::Project,
+    ext::{
+        fs,
+        sync::{wait_interruptible, CommandResult},
+        PathBufExt,
+    },
+    internal_prelude::*,
+    logger::GRAY,
+    signal::{Interrupt, Outcome, Product},
+};
 use camino::Utf8Path;
 use std::sync::Arc;
-use swc::config::IsModule;
-use swc::JsMinifyExtras;
-use swc::{config::JsMinifyOptions, try_with_handler, BoolOrDataConfig};
+use swc::{
+    config::{IsModule, JsMinifyOptions},
+    try_with_handler, BoolOrDataConfig, JsMinifyExtras,
+};
 use swc_common::{FileName, SourceMap, GLOBALS};
-use tokio::process::Child;
-use tokio::{process::Command, task::JoinHandle};
+use tokio::{
+    process::{Child, Command},
+    task::JoinHandle,
+};
 use wasm_bindgen_cli_support::Bindgen;
 use wasm_opt::OptimizationOptions;
 
@@ -87,7 +95,7 @@ pub fn build_cargo_front_cmd(
 
     proj.lib.profile.add_to_args(&mut args);
 
-    let envs = proj.to_envs();
+    let envs = proj.to_envs(wasm);
 
     let envs_str = envs
         .iter()
@@ -96,6 +104,7 @@ pub fn build_cargo_front_cmd(
         .join(" ");
 
     command.args(&args).envs(envs);
+
     let line = super::build_cargo_command_string(args);
     trace!(?envs_str, ?line, "Constructed cargo build front cmd");
     (envs_str, line)

--- a/src/compile/server.rs
+++ b/src/compile/server.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use super::ChangeSet;
-use crate::internal_prelude::*;
 use crate::{
     config::Project,
     ext::sync::{wait_interruptible, CommandResult},
+    internal_prelude::*,
     logger::GRAY,
     signal::{Interrupt, Outcome, Product},
 };
@@ -116,7 +116,7 @@ pub fn build_cargo_server_cmd(
     }
     proj.bin.profile.add_to_args(&mut args);
 
-    let envs = proj.to_envs();
+    let envs = proj.to_envs(false);
 
     let envs_str = envs
         .iter()

--- a/src/service/serve.rs
+++ b/src/service/serve.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use crate::internal_prelude::*;
 use crate::{
     config::Project,
     ext::{append_str_to_filename, determine_pdb_filename, fs, Paint},
+    internal_prelude::*,
     logger::GRAY,
     signal::{Interrupt, ReloadSignal, ServerRestart},
 };
@@ -63,7 +63,7 @@ impl ServerProcess {
     fn new(proj: &Project) -> Self {
         Self {
             process: None,
-            envs: proj.to_envs(),
+            envs: proj.to_envs(false),
             binary: proj.bin.exe_file.clone(),
             bin_args: proj.bin.bin_args.clone(),
         }


### PR DESCRIPTION
I found the trick. #499 follow-up (I closed it and couldn't reopen it).

@benwis This PR works as expected. Please check it out. The only concern about his feature is that we should make sure the leptos examples will not run on debug builds as it will  be always on `erase_components` (Not related to this PR).