### PR TITLE
Only return from build_proj after initially building all asset types. (Fixes #300)

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -33,13 +33,19 @@ pub async fn build_proj(proj: &Arc<Project>) -> Result<bool> {
     }
     let changes = ChangeSet::all_changes();
 
+    let mut success = true;
+
     if !compile::front(proj, &changes).await.await??.is_success() {
-        return Ok(false);
+        success = false;
     }
     if !compile::assets(proj, &changes).await.await??.is_success() {
-        return Ok(false);
+        success = false;
     }
     if !compile::style(proj, &changes).await.await??.is_success() {
+        success = false;
+    }
+
+    if !success {
         return Ok(false);
     }
 


### PR DESCRIPTION
In the muture we might also want to tackle the `add_hashes_to_site` case and the case of `build` vs `watch`, but for now I think this is sufficient, and having used this for a couple of months I haven't seen any problems.

Fixes #300