### PR TITLE
fix: Prioritize configured target triple over host target_os for binary extension selection

### DIFF
--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -81,12 +81,12 @@ impl BinPackage {
             &config.bin_profile_dev,
         );
         let exe_file = {
-            let file_ext = if cfg!(target_os = "windows")
-                && config
-                    .bin_target_triple
-                    .as_ref()
-                    .is_none_or(|triple| triple.contains("-pc-windows-"))
-            {
+            let file_ext = if config
+                .bin_target_triple
+                .as_ref()
+                .map_or(cfg!(target_os = "windows"), |triple| {
+                    triple.contains("-pc-windows-")
+                }) {
                 "exe"
             } else if config
                 .bin_target_triple


### PR DESCRIPTION
Previously, the binary extension (e.g., `.exe` for Windows) was chosen based on the host `target_os`, ignoring the configured `bin-target-triple`. This caused incorrect extensions for cross-compiled binaries. 