### PR TITLE
enh: support Tailwind sanitized version as input

### DIFF
--- a/src/config/tailwind.rs
+++ b/src/config/tailwind.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 
 use super::{ProjectConfig, VersionConfig};
-use crate::internal_prelude::*;
+use crate::{ext::exe::sanitize_version_prefix, internal_prelude::*};
 
 #[derive(Clone, Debug)]
 pub struct TailwindConfig {
@@ -21,9 +21,12 @@ impl TailwindConfig {
             return Ok(None);
         };
 
-        let is_v_4 = VersionConfig::Tailwind.version().starts_with("v4");
+        let version = VersionConfig::Tailwind.version();
+        let sanitized_version =
+            sanitize_version_prefix(version.as_ref()).unwrap_or(version.as_ref());
+        let is_v4 = sanitized_version.starts_with("4.") || sanitized_version == "4";
 
-        let config_file = if is_v_4 {
+        let config_file = if is_v4 {
             if conf.tailwind_config_file.is_some()
                 || conf.config_dir.join("tailwind.config.js").exists()
             {

--- a/src/config/version.rs
+++ b/src/config/version.rs
@@ -17,7 +17,7 @@ impl VersionConfig {
 
     pub fn default_version(&self) -> &'static str {
         match self {
-            Self::Tailwind => "v4.1.4",
+            Self::Tailwind => "4.1.4",
             Self::Sass => "1.86.0",
         }
     }


### PR DESCRIPTION
I'm usually very confused when I realize after some debug that the environment variable `LEPTOS_TAILWIND_VERSION` does not accept a version without a `v` prefix. This PR implements sanitization for Tailwind version prefixes.

After this, you can pass `LEPTOS_TAILWIND_VERSION=4.1.7` as well as `LEPTOS_TAILWIND_VERSION=v4.1.7`. The only drawback is that the cache will be invalidated because, after this change, the prefixes in version parts of cache directory names are sanitized.