### PR TITLE
Fix name for brackets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ lib-package = "front"
 # more configuration parameters...
 ```
 
-Note the double braces: several projects can be defined and one package can be used in several projects.
+Note the double square brackets: several projects can be defined and one package can be used in several projects.
 
 <br/>
 


### PR DESCRIPTION
I believe "braces" always refer to { } characters. The name for [ ] is brackets (american english) or square brackets (british english). Using the square form here makes it unambiguous.

Source: https://en.wikipedia.org/wiki/Bracket