### PR TITLE
Attempt to fix release builds failing with wasm-opt

### DIFF
--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -199,6 +199,8 @@ async fn bindgen(proj: &Project) -> Result<Outcome<Product>> {
 
 fn optimize(file: &Utf8Path) -> Result<()> {
     OptimizationOptions::new_optimize_for_size_aggressively()
+        .enable_feature(wasm_opt::Feature::BulkMemory)
+        .enable_feature(wasm_opt::Feature::TruncSat)
         .run(file, file)
         .dot()
 }


### PR DESCRIPTION
See #526

Enables the two features that LLVM 20 enabled to try to fix the release builds failing at wasm-opt with Rust 1.87.

Seems like this should have fixed it but I tried it and I get the same error (just with the line number pushed down two lines.