### PR TITLE
Enable nontrapping-fptoint feature while invoking wasm-opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ disable-erase-components = false
 
 # Enabling wasm-opt features
 #
-# Optional. By default, "-Oz" and "--enable-bulk-memory" are used. For all features, consult `wasm-opt --help`.
+# Optional. By default, "-Oz", "--enable-bulk-memory" and "--enable-nontrapping-float-to-int"  are used. For all features, consult `wasm-opt --help`.
 # By providing features, you will override the default enabled features.
-wasm-opt-features = ["-Oz","--enable-bulk-memory"]
+wasm-opt-features = ["-Oz","--enable-bulk-memory","--enable-nontrapping-float-to-int"]
 ```
 
 ## Site parameters

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -202,7 +202,7 @@ async fn optimize(proj: &Project, file: &Utf8Path) -> Result<()> {
     let mut args: Vec<&str> = if let Some(features) = &proj.wasm_opt_features {
         features.iter().map(|f| f.as_str()).collect()
     } else {
-        vec!["-Oz", "--enable-bulk-memory"]
+        vec!["-Oz", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
     };
     args.extend_from_slice(&[file.as_str(), "-o", file.as_str()]);
 


### PR DESCRIPTION
Without enabling this feature, trying to build a  Leptos project in release profile with strip enabled results in errors such as:
```    wasm-opt failed with:
[wasm-validator error in function 27] unexpected false: all used features should be allowed, on 
(i32.trunc_sat_f64_u
 (local.get $8)
)
[wasm-validator error in function 27] unexpected false: all used features should be allowed, on 
(i32.trunc_sat_f64_u
 (local.get $9)
)
[wasm-validator error in function 207] unexpected false: all used features should be allowed, on 
(i32.trunc_sat_f64_u
 (local.get $4)
)
Fatal: error validating input
```
See https://github.com/rust-lang/rust/pull/137322