### PR TITLE
Implement --frontend-only and --backend-only options for build commands

### DIFF
--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -22,6 +22,8 @@ fn release_opts() -> Opts {
         lib_cargo_args: None,
         wasm_debug: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     }
 }
 fn dev_opts() -> Opts {
@@ -39,6 +41,8 @@ fn dev_opts() -> Opts {
         lib_cargo_args: None,
         wasm_debug: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     }
 }
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -63,6 +63,14 @@ pub struct Opts {
     /// Split WASM binary based on #[lazy] macros.
     #[arg(long)]
     pub split: bool,
+
+    /// Only build the frontend.
+    #[arg(long)]
+    pub frontend_only: bool,
+
+    /// Only build the server.
+    #[arg(long, conflicts_with="frontend_only")]
+    pub server_only: bool,
 }
 
 #[derive(Debug, Clone, Parser, PartialEq, Default)]

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -51,6 +51,8 @@ pub struct Project {
     pub always_erase_components: bool,
     pub server_fn_mod_path: bool,
     pub wasm_opt_features: Option<HashSet<String>>,
+    pub build_frontend_only: bool,
+    pub build_server_only: bool,
 }
 
 impl Debug for Project {
@@ -144,6 +146,8 @@ impl Project {
                 always_erase_components: config.always_erase_components,
                 server_fn_mod_path: config.server_fn_mod_path,
                 wasm_opt_features: config.wasm_opt_features,
+                build_frontend_only: cli.frontend_only,
+                build_server_only: cli.server_only,
             };
             resolved.push(Arc::new(proj));
         }

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -177,6 +177,8 @@ Config {
         verbose: 0,
         js_minify: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -106,6 +106,8 @@ Config {
         verbose: 0,
         js_minify: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -99,6 +99,8 @@ Config {
         verbose: 0,
         js_minify: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -99,6 +99,8 @@ Config {
         verbose: 0,
         js_minify: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -101,6 +101,8 @@ Config {
         verbose: 0,
         js_minify: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     },
     watch: true,
     ..

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -15,6 +15,8 @@ fn opts(project: Option<&str>) -> crate::config::Opts {
         lib_cargo_args: None,
         wasm_debug: false,
         split: false,
+        frontend_only: false,
+        server_only: false,
     }
 }
 


### PR DESCRIPTION
My PaaS prefers to have backends built in their own CI runners, but they're slow, so this lets me build the frontend in my own (faster) CI and then push the generated `target/site` along with the rest of the codebase into their CI.