### PR TITLE
fix: support file hashing when using lazy loading

### DIFF
--- a/src/wasm_split_tools/mod.rs
+++ b/src/wasm_split_tools/mod.rs
@@ -177,7 +177,7 @@ function makeLoad(url, deps) {
             .dest
             .parent()
             .expect("no destination directory")
-            .join("__wasm_split.js"),
+            .join("__wasm_split.______________________.js"),
         javascript,
     )
     .await?;


### PR DESCRIPTION
This supports the combination of lazy-loading and file-hashing by special-casing `__wasm_split.js`, which both refers to hashed files and is referred to by WASM binary files.

Needs to be used alongside https://github.com/leptos-rs/leptos/pull/4182.

Closes #552