### PR TITLE
Add shell completions to `cargo-leptos`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "cargo-generate",
  "cargo_metadata",
  "clap",
+ "clap_complete",
  "color-eyre",
  "derive_more",
  "dirs",
@@ -740,6 +741,15 @@ dependencies = [
  "clap_lex",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ walkdir = "2.5"
 regex = "1.11.1"
 wasm-encoder = { version = "0.235.0", features = ["wasmparser"] }
 wasmparser = "0.235.0"
+clap_complete = "4.5.55"
 
 [dev-dependencies]
 insta = { version = "1.43", features = ["yaml"] }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ install it with the `no_downloads` feature enabled to prevent cargo-leptos from 
 
 <br/>
 
+## Completions
+
+For at least some shells (`bash` and `zsh` are confirmed to work) `cargo` is able to forward completions from custom
+commands like `cargo leptos` back to the underlying `cargo-leptos` binary.
+
+For that purpose `cargo-leptos` supports generating completions using `cargo leptos completions <SHELL>`.
+Which you then can install/source for your shell.
+
 # Single-package setup
 
 The single-package setup is where the code for both the frontend and the server is defined in a single package.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ For at least some shells (`bash` and `zsh` are confirmed to work) `cargo` is abl
 commands like `cargo leptos` back to the underlying `cargo-leptos` binary.
 
 For that purpose `cargo-leptos` supports generating completions using `cargo leptos completions <SHELL>`.
-Which you then can install/source for your shell.
+Which you then can install/source for your shell. For bash, the command could like this 
+```bash
+cargo leptos completions bash > "${XDG_DATA_HOME:-"$HOME/.local/share}/bash-completion/completions/cargo-leptos"
+```
 
 # Single-package setup
 

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -64,15 +64,13 @@ pub async fn build_proj(proj: &Arc<Project>) -> Result<bool> {
 
     let changes = ChangeSet::all_changes();
 
-    if !proj.build_server_only
-        && !build_frontend(proj, &changes).await? {
-            return Ok(false);
-        }
+    if !proj.build_server_only && !build_frontend(proj, &changes).await? {
+        return Ok(false);
+    }
 
-    if !proj.build_frontend_only
-        && !compile::server(proj, &changes).await.await??.is_success() {
-            return Ok(false);
-        }
+    if !proj.build_frontend_only && !compile::server(proj, &changes).await.await??.is_success() {
+        return Ok(false);
+    }
 
     Ok(true)
 }

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -225,7 +225,11 @@ async fn optimize(proj: &Project, file: &Utf8Path) -> Result<()> {
     let mut args: Vec<&str> = if let Some(features) = &proj.wasm_opt_features {
         features.iter().map(|f| f.as_str()).collect()
     } else {
-        vec!["-Oz", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
+        vec![
+            "-Oz",
+            "--enable-bulk-memory",
+            "--enable-nontrapping-float-to-int",
+        ]
     };
     args.extend_from_slice(&[file.as_str(), "-o", file.as_str()]);
 

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -21,16 +21,16 @@ use itertools::Itertools;
 use tokio::process::Command;
 
 fn build_cargo_command_string(command: &Command) -> String {
-  let std_command = command.as_std();
-  let program = std_command.get_program();
-  let args = std_command.get_args();
+    let std_command = command.as_std();
+    let program = std_command.get_program();
+    let args = std_command.get_args();
 
-  [program]
-    .into_iter()
-    .chain(args)
-    .map(|arg| match arg.to_string_lossy() {
-      arg if arg.contains(' ') => format!("'{arg}'"),
-      arg => arg.into_owned(),
-    })
-    .join(" ")
+    [program]
+        .into_iter()
+        .chain(args)
+        .map(|arg| match arg.to_string_lossy() {
+            arg if arg.contains(' ') => format!("'{arg}'"),
+            arg => arg.into_owned(),
+        })
+        .join(" ")
 }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,6 +1,7 @@
 use crate::command::NewCommand;
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Log {
@@ -69,7 +70,7 @@ pub struct Opts {
     pub frontend_only: bool,
 
     /// Only build the server.
-    #[arg(long, conflicts_with="frontend_only")]
+    #[arg(long, conflicts_with = "frontend_only")]
     pub server_only: bool,
 }
 
@@ -105,6 +106,7 @@ impl Cli {
             Commands::Build(opts) | Commands::Test(opts) | Commands::EndToEnd(opts) => {
                 Some(opts.clone())
             }
+            _ => None,
         }
     }
 
@@ -113,6 +115,7 @@ impl Cli {
             Commands::New(_) => None,
             Commands::Serve(bin_opts) | Commands::Watch(bin_opts) => Some(&mut bin_opts.opts),
             Commands::Build(opts) | Commands::Test(opts) | Commands::EndToEnd(opts) => Some(opts),
+            _ => None,
         }
     }
 
@@ -140,4 +143,7 @@ pub enum Commands {
     Watch(BinOpts),
     /// Start a wizard for creating a new project (using cargo-generate).
     New(NewCommand),
+
+    /// Generate shell for `cargo-leptos`
+    Completions { shell: Shell },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@ pub mod compile;
 pub mod config;
 pub mod ext;
 pub mod logger;
-pub mod wasm_split_tools;
 pub mod service;
 pub mod signal;
+pub mod wasm_split_tools;
 mod internal_prelude {
     pub use crate::ext::{eyre::reexports::*, Paint as _};
     pub use tracing::*;


### PR DESCRIPTION

Since `cargo` now supports forwarding of shell completions of `cargo
<custom-cmd>` to `cargo-<custom-cmd>` for at least `bash` and `zsh`,
providing the backing completions seems useful.

They still have to be manually installed by the user, for `bash` that can be
done by either running `eval "$(cargo leptos completions bash)"` to enable the
completions for the *current* session and

```bash
cargo leptos completions bash > "${XDG_DATA_HOME:-"$HOME/.local/share}/bash-completion/completions/cargo-leptos"
```

to let `bash` lazily load the completions as soon as they are needed.

For `zsh` I'm not quite sure how they are working, but considering how other
projects manage autocompletions, describing the details of how the shells
completions work, might be not really necessary *anyway*.