### PR TITLE
fix: truncate long filenames (closes #556)

### DIFF
--- a/src/wasm_split_tools/split_point.rs
+++ b/src/wasm_split_tools/split_point.rs
@@ -258,8 +258,8 @@ impl SplitModuleIdentifier {
             Self::Split { name, .. } => name.clone(),
             Self::Chunk { splits, hash } => {
                 let mut full_name = splits.join("_");
-                if full_name.len() > 200 {
-                    full_name.truncate(200);
+                if full_name.len() > 128 {
+                    full_name.truncate(128);
                     full_name.push_str(hash);
 
                     let mut hasher = DefaultHasher::new();
@@ -279,8 +279,8 @@ impl SplitModuleIdentifier {
             Self::Split { name, hash } => format!("{name}.{hash}"),
             Self::Chunk { splits, hash } => {
                 let mut splits = splits.join("_");
-                if splits.len() > 200 {
-                    splits.truncate(200);
+                if splits.len() > 128 {
+                    splits.truncate(128);
                 }
                 format!("{splits}.{hash}")
             }


### PR DESCRIPTION
@Sliman4 I don't have a way to reproduce issue #556 but this seems to me to be a reasonable way to truncate long filenames. Does it fix your issue?