### PR TITLE
fix: handle additional wbindgen descriptor names in splitting code

### DIFF
--- a/src/wasm_split_tools/mod.rs
+++ b/src/wasm_split_tools/mod.rs
@@ -191,5 +191,9 @@ function makeLoad(url, deps) {
 }
 
 fn is_wasm_bindgen_descriptor(name: &str) -> bool {
-    name == "__wbindgen_describe_closure" || name == "__wbindgen_describe"
+    name == "__wbindgen_describe_closure"
+        || name == "__wbindgen_describe"
+        || name.contains("wasm_bindgen..describe..WasmDescribe")
+        || name.contains("wasm_bindgen..closure..WasmClosure")
+        || name.contains("wasm_bindgen7closure16Closure")
 }


### PR DESCRIPTION
See https://github.com/leptos-rs/leptos/issues/4347

This added combination of problematic `wasm-bindgen` descriptor names slightly expands the set of functions that can't be split out due to their need to be processed by the `wasm-bindgen` CLI. 