### PR TITLE
Document openssl-sys dependency requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Install:
 
 > `cargo install --locked cargo-leptos`
 
+Note that this may require additional dependencies for SSL on some systems.
+If the installation fails while building `openssl-sys`, you will need to
+[install additional tools](https://docs.rs/openssl/latest/openssl/#automatic),
+before retrying the build.
+
 If you, for any reason, need the bleeding-edge super fresh version:
 
 > `cargo install --git https://github.com/leptos-rs/cargo-leptos --locked cargo-leptos`


### PR DESCRIPTION
I, like many other users, ran into issues installing `cargo-leptos` due to struggles getting its `openssl-sys` dependency to build.

As per @benwis 's comment on #479, it'd be nice to switch to rusttls, which would probably be easier to compile, but in the mean-time, updating the readme to warn future users of this potential pain-point will help future users resolve it themselves. As such, I have added a link to the `openssl` crate's documentation, which specifies the dependencies required for compilation.