### PR TITLE
feat: detect wasm-bindgen version from project Cargo.lock (#588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "camino",
  "cargo-config2",
  "cargo-generate",
+ "cargo-lock",
  "cargo_metadata",
  "clap",
  "clap_complete",
@@ -622,6 +623,18 @@ dependencies = [
  "wasm_split_cli_support",
  "which",
  "zip",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf53e0ebbbc6e45357b199f3b213f3eb330792c8b370e548499f5685470ecb11"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 0.9.8",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ axum = { version = "0.8.4", features = ["ws"] }
 notify-debouncer-full = "0.5.0"
 which = "8.0"
 cargo_metadata = { version = "0.21.0", features = ["builder"] }
+cargo-lock = "11"
 serde_json = "1.0"
 reqwest = { version = "0.12.22", features = [
   "blocking",

--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -157,7 +157,7 @@ async fn bindgen(proj: &Project, all_wasm_files: &[Utf8PathBuf]) -> Result<Outco
         .generate_output()
         .dot_anyhow()?; */
 
-    let wasm_opt = Exe::WasmBindgen.get().await.dot()?;
+    let wasm_bindgen = Exe::WasmBindgen.get(Some(&proj.working_dir)).await.dot()?;
 
     let args = [
         Some("--target=web".to_string()),
@@ -175,7 +175,7 @@ async fn bindgen(proj: &Project, all_wasm_files: &[Utf8PathBuf]) -> Result<Outco
     .into_iter()
     .flatten();
 
-    let mut cmd = Command::new(wasm_opt);
+    let mut cmd = Command::new(wasm_bindgen);
     cmd.args(args.clone());
 
     match wait_piped_interruptible(
@@ -254,7 +254,7 @@ async fn bindgen(proj: &Project, all_wasm_files: &[Utf8PathBuf]) -> Result<Outco
 }
 
 async fn optimize(proj: &Project, file: &Utf8Path) -> Result<()> {
-    let wasm_opt = Exe::WasmOpt.get().await.dot()?;
+    let wasm_opt = Exe::WasmOpt.get(None).await.dot()?;
 
     let mut args: Vec<&str> = if let Some(features) = &proj.wasm_opt_features {
         features.iter().map(|f| f.as_str()).collect()

--- a/src/compile/sass.rs
+++ b/src/compile/sass.rs
@@ -15,7 +15,7 @@ pub async fn compile_sass(style_file: &SourcedSiteFile, optimise: bool) -> Resul
     let mut args = vec![style_file.source.as_str()];
     optimise.then(|| args.push("--no-source-map"));
 
-    let exe = Exe::Sass.get().await.dot()?;
+    let exe = Exe::Sass.get(None).await.dot()?;
 
     let mut cmd = Command::new(exe);
     cmd.args(&args);

--- a/src/compile/tailwind.rs
+++ b/src/compile/tailwind.rs
@@ -83,7 +83,7 @@ pub async fn tailwind_process(
     cmd: &str,
     tw_conf: &TailwindConfig,
 ) -> Result<(String, Command)> {
-    let tailwind = Exe::Tailwind.get().await.dot()?;
+    let tailwind = Exe::Tailwind.get(None).await.dot()?;
 
     let mut args = vec!["--input", tw_conf.input_file.as_str()];
 


### PR DESCRIPTION
This MR implements #588:

Automatically detects and uses the `wasm-bindgen` version from the project's `Cargo.lock` file instead of immediately falling back to a hard-coded default version. This ensures version compatibility between the `wasm-bindgen` dependency and the `wasm-bindgen-cli` tool.

**Edit: I provided an alternate approach (with I prefer) as https://github.com/leptos-rs/cargo-leptos/pull/590.** Details of the alternate approach are discussed further down below.

The `LEPTOS_WASM_BINDGEN_VERSION` variable still has the highest priority, to not break the public API.

**Version resolution priority:**

1. `LEPTOS_WASM_BINDGEN_VERSION` environment variable (highest)
2. Version from project's `Cargo.lock`
3. Hard-coded default version (`0.2.104`)

**Implementation details:**

- Adds [`cargo-lock`](https://crates.io/crates/cargo-lock) dependency for parsing `Cargo.lock` files. (Solid dependency from [`rustsec`](https://github.com/rustsec/rustsec/tree/main/cargo-lock).)
- Creates `detect_wasm_bindgen_from_lockfile()` helper function.
- Updates `Exe::get()` to accept optional project root path parameter.
- Threads `project_root` through `Command` trait methods.

**Design decision:**

The project root path is passed as an optional parameter to `Exe::get()` rather than making `WasmBindgen` a tuple struct variant with an embedded path. This avoids adding lifetime parameters to the `Exe` enum and keeps the API simpler, at the cost of requiring `None` for tools that don't need project context.

This approach is less involved, but not entirely aesthetic. **I am hoping for your input here:**

If you prefer, I can instead provide a solution with `Exe<'a>::WasmBindgen(&'a Utf8Path)` and `struct CommandWasmBindgen<'a>(&'a Utf8Path)` (or alternatively a named struct field `project_root`, rather than tuple structs &mdash; let me know what you prefer).

This way, the root path would not need to be passed through `Exe::get` and `Exe::get_meta`, as well `Command::exe_meta` (which, as `trait` `fn`, requires the other commands to also accept the project root parameter). 

Instead, `Exe::meta` would deconstruct `Exe::WasmBindgen(project_root)` (or `Exe::WasmBindgen { project_root }`), create a `CommandWasmBindgen(project_root)` (or `CommandWasmBindgen { project_root }`) and call `Command::exe_meta` on that, without modifying the trait.

Since the current API treats all `Exe`s and `Command`s the same, I wasn't sure which diverging solution you would prefer.
I personally prefer the second option, for it is cleaner and more aesthetic. But the first approach might be preferable in case the versions of `dart-sass`, `tailwindcss` and `wasm-opt` might in the future also be determined by inspecting the project, which would make passing the project root path to all command resolvers useful.

Please let me know if I should modify the MR.

**Edit: I provided the alternate approach (with I prefer) as https://github.com/leptos-rs/cargo-leptos/pull/590.**