### PR TITLE
Work around repeated watch notifications on MacOS (#587)

### DIFF
--- a/src/service/notify.rs
+++ b/src/service/notify.rs
@@ -103,8 +103,7 @@ fn handle(
                 .iter()
                 .filter_map(|p| {
                     let mtime = fs::metadata(&p)
-                        .map(|meta| meta.modified())
-                        .flatten()
+                        .and_then(|meta| meta.modified())
                         .unwrap_or(SystemTime::UNIX_EPOCH);
 
                     if watcher


### PR DESCRIPTION
As discussed in #587, MacOS sends file modification events when files are cloned from the asset directory to the built site. The spurious events are difficult to distinguish from the genuine ones, so rather than attempt to do that, I record the file modification time when an event is received. If a second event is received, but the file mtime has not changed, it can be assumed to be spurious and discarded.

Please let me know what you think—is this the approach you'd like to take to resolving this issue?