### PR TITLE
#598 fixing wasm-bindgen interruption not terminates watch loop

### DIFF
--- a/src/compile/front.rs
+++ b/src/compile/front.rs
@@ -190,7 +190,9 @@ async fn bindgen(proj: &Project, all_wasm_files: &[Utf8PathBuf]) -> Result<Outco
     )
     .await?
     {
-        CommandResult::Interrupted => bail!("wasm-bindgen interrupted"),
+        CommandResult::Interrupted => {
+            Ok(Outcome::Stopped)
+        },
         CommandResult::Failure(output) => {
             error!("wasm-bindgen failed with:");
             println!("{}", output.stderr());


### PR DESCRIPTION
I triggered the rebuild a few times and with a println!("...") I've checked that it triggered this case. After 20 rounds I did not see any stuck wasm-bindgen calls:

```bash
nixos     226379  265  3.9 1066644 635100 pts/4  Rl+  15:33   0:07 /nix/store/43kv7rfahiarb7a2fb2dnj8kw2z7fdfq-wasm-bindgen-cli-0.2.100/bin/wasm-bindgen --target=web --out-name=planicus --out-dir=target/site/pkg target/front/wasm32-unknown-unknown/debug/frontend.wasm
```

Was closed properly.