### PR TITLE
fix: io-errors from .gitignore ignored

### DIFF
--- a/src/service/notify.rs
+++ b/src/service/notify.rs
@@ -294,7 +294,14 @@ impl GitAwareWatcher {
     fn new_gitignore(gitignore_path: &Path) -> Gitignore {
         info!("Creating ignore list from '.gitignore' file");
 
-        let mut builder = GitignoreBuilder::new(gitignore_path.parent().unwrap_or(Path::new("/")));
+        let glob_dir = match gitignore_path.parent() {
+            Some(dir) => dir,
+            None => {
+                error!("Could not determine parent directory of '.gitignore' file\nThis causes the watcher to work expensively on file changes like changes in the 'target' path.\nCreate a '.gitignore' file and exclude common build and cache paths like 'target'");
+                return Gitignore::empty();
+            }
+        };
+        let mut builder = GitignoreBuilder::new(glob_dir);
         let err = builder.add(gitignore_path);
         if let Some(err) = err {
             error!("Failed reading '.gitignore' file in the working directory: {err}\nThis causes the watcher to work expensively on file changes like changes in the 'target' path.\nCreate a '.gitignore' file and exclude common build and cache paths like 'target'");


### PR DESCRIPTION
Fixes #605
## Intended behavior
When running `cargo-leptos watch` the following error should be printed if the `.gitignore` file is missing:
```
Failed reading '.gitignore' file in the working directory: {err}
This causes the watcher to work expensively on file changes like changes in the 'target' path.
Create a '.gitignore' file and exclude common build and cache paths like 'target'
```

## Current behavior
IO-errors are ignored, the error is not printed if the file is missing.

## Fix
From `Gitignore::new`:
```
    /// Note that I/O errors are ignored. For more granular control over
    /// errors, use `GitignoreBuilder`.
```
Now it is using `GitignoreBuilder` and does not ignore `IO` errors, further in case the file is there but invalid I added a more specific error message, otherwise the behavior remains the same (I pretty much just inlined `Gitignore::new`).

## Further work
Now that the error is working this means, that it will also be printed if running `cargo-leptos` with the current working directory in one of the examples. Should we perhaps also try to look in a parent folder for a `.gitignore` file or something similar? I could also create a PR for that.

