### PR TITLE
fix: missing error on conflicting assets

### DIFF
--- a/src/compile/assets.rs
+++ b/src/compile/assets.rs
@@ -103,12 +103,11 @@ async fn mirror(src_root: &Utf8Path, dest_root: &Utf8Path, reserved: &[Utf8PathB
     // reserved paths should be relative to the source root
     for r in reserved {
         if r.exists() {
-            error!(
-                "Assets source {} contains path {} reserved for Leptos. Please move or remove it.",
-                GRAY.paint(src_root.as_str()),
-                GRAY.paint(r.as_str())
-            );
-            return Err(Error::msg("Assets reserved path exists in source"));
+            return Err(eyre!(
+                "Assets source {} contains path {} reserved for Leptos.\nThe build process potentially generates files at the same location in the site directory, so the asset cannot be copied to the site directory.\nPlease move, rename or remove this file or directory.",
+                src_root,
+                r,
+            ));
         }
     }
 


### PR DESCRIPTION
This PR addresses:
- Fixes #392: Unclear error message on missing asset dir. Also changed this from an error to a warning, as it should be in my opinion
- Fixes: Empty warning message when asset conflicted with a reserved path. Also changes this from a warning to an error, as it used to be. I can change that back if desired.
- Fixes: Conflict check does not work with multi-dir pkg_dir. Never reports a warning in that case.