### PR TITLE
feat: allow lib renames in Cargo.toml

### DIFF
--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -4,7 +4,7 @@ use cargo_metadata::{Metadata, Target};
 use super::{project::ProjectDefinition, Profile, ProjectConfig};
 use crate::{
     config::Opts,
-    ext::{MetadataExt, PackageExt, PathBufExt, PathExt},
+    ext::{MetadataExt, PathBufExt, PathExt},
     internal_prelude::*,
 };
 pub struct BinPackage {
@@ -48,7 +48,7 @@ impl BinPackage {
         let packages = metadata.workspace_packages();
         let package = packages
             .iter()
-            .find(|p| *p.name == name && p.has_bin_target())
+            .find(|p| *p.name == name)
             .ok_or_else(|| eyre!(r#"Could not find the project bin-package "{name}""#,))?;
 
         let package = (*package).clone();

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -48,8 +48,9 @@ impl LibPackage {
 
         let Some(target_lib) = package.cdylib_target() else {
             return Err(eyre!(
-                "Cargo.toml has leptos metadata but is missing a cdylib library target. {}",
-                GRAY.paint(package.manifest_path.as_str())
+                r#"Could not find a cdylib library target for the leptos lib-package "{}" defined in {}"#,
+                package.name,
+                GRAY.paint(package.manifest_path.as_str()),
             ));
         };
 
@@ -78,7 +79,7 @@ impl LibPackage {
                 .join("front")
                 .join("wasm32-unknown-unknown")
                 .join(profile.to_string())
-                .join(target_lib.name.replace('-', "_"))
+                .join(target_lib.name.clone())
                 .with_extension("wasm");
             let site = config
                 .site_pkg_dir

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -1,8 +1,7 @@
 use crate::{
     config::{hash_file::HashFile, lib_package::LibPackage},
-    ext::{PackageExt, Paint, PathBufExt, PathExt},
+    ext::{PathBufExt, PathExt},
     internal_prelude::*,
-    logger::GRAY,
     service::site::Site,
 };
 use camino::{Utf8Path, Utf8PathBuf};
@@ -455,17 +454,6 @@ impl ProjectDefinition {
         cargo_metadata: &Metadata,
     ) -> Result<(Self, ProjectConfig)> {
         let conf = ProjectConfig::parse(dir, metadata, cargo_metadata)?;
-
-        ensure!(
-            package.cdylib_target().is_some(),
-            "Cargo.toml has leptos metadata but is missing a cdylib library target. {}",
-            GRAY.paint(package.manifest_path.as_str())
-        );
-        ensure!(
-            package.has_bin_target(),
-            "Cargo.toml has leptos metadata but is missing a bin target. {}",
-            GRAY.paint(package.manifest_path.as_str())
-        );
 
         Ok((
             ProjectDefinition {

--- a/src/ext/eyre.rs
+++ b/src/ext/eyre.rs
@@ -5,7 +5,7 @@ pub(crate) mod reexports {
     //! re-exports
 
     pub use super::{AnyhowCompatWrapErr as _, CustomWrapErr as _};
-    pub use color_eyre::eyre::{self, anyhow, bail, ensure, eyre, Report as Error, Result};
+    pub use color_eyre::eyre::{self, anyhow, bail, eyre, Report as Error, Result};
 }
 use reexports::*;
 


### PR DESCRIPTION
Fixes #415
Previously lead to failure to find .wasm files

Related to #41 and could be seen as a fix for it. See this [comment](https://github.com/leptos-rs/cargo-leptos/issues/41#issuecomment-1738136065)

The second commit reworks the error handling, some error reporting was duplicated when `from_project` was used instead of `from_workspace`.