### PR TITLE
add [--target] flag to cli build sub command for cross compiling server binary.

### DIFF
--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -24,6 +24,7 @@ fn release_opts() -> Opts {
         frontend_only: false,
         server_only: false,
         clear: false,
+        target: None,
     }
 }
 fn dev_opts() -> Opts {
@@ -44,6 +45,7 @@ fn dev_opts() -> Opts {
         frontend_only: false,
         server_only: false,
         clear: false,
+        target: None,
     }
 }
 

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -80,16 +80,15 @@ impl BinPackage {
             &config.bin_profile_release,
             &config.bin_profile_dev,
         );
+        let target_triple = cli.target.clone().or_else(|| config.bin_target_triple.clone());
         let exe_file = {
-            let file_ext = if config
-                .bin_target_triple
+            let file_ext = if target_triple
                 .as_ref()
                 .map_or(cfg!(target_os = "windows"), |triple| {
                     triple.contains("-pc-windows-")
                 }) {
                 "exe"
-            } else if config
-                .bin_target_triple
+            } else if target_triple
                 .as_ref()
                 .is_some_and(|target| target.starts_with("wasm32-"))
             {
@@ -104,7 +103,7 @@ impl BinPackage {
                 .map(|dir| dir.into())
                 // Can't use absolute path because the path gets stored in snapshot testing, and it differs between developers
                 .unwrap_or_else(|| metadata.rel_target_dir());
-            if let Some(triple) = &config.bin_target_triple {
+            if let Some(triple) = &target_triple {
                 file = file.join(triple)
             };
             let name = if let Some(name) = &config.bin_exe_name {
@@ -140,7 +139,7 @@ impl BinPackage {
             default_features: config.bin_default_features,
             src_paths,
             profile,
-            target_triple: config.bin_target_triple.clone(),
+            target_triple,
             target_dir: config.bin_target_dir.clone(),
             cargo_command: config.bin_cargo_command.clone(),
             cargo_args,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -76,6 +76,10 @@ pub struct Opts {
     /// Only build the server.
     #[arg(long, conflicts_with = "frontend_only")]
     pub server_only: bool,
+
+    /// Target triple for the server binary (e.g. x86_64-unknown-linux-gnu). Overrides bin-target-triple in Cargo.toml.
+    #[arg(long)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser, PartialEq, Default)]
@@ -176,4 +180,5 @@ pub enum Commands {
 
     /// Generate shell for `cargo-leptos`
     Completions { shell: Shell },
+
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -53,6 +53,7 @@ pub struct Project {
     pub build_frontend_only: bool,
     pub build_server_only: bool,
     pub clear_terminal_on_rebuild: bool,
+    pub target: Option<String>,
 }
 
 impl Debug for Project {
@@ -149,6 +150,7 @@ impl Project {
                 wasm_opt_features: config.wasm_opt_features,
                 build_frontend_only: cli.frontend_only,
                 build_server_only: cli.server_only,
+                target: cli.target.clone().or_else(|| config.bin_target_triple.clone()),
             };
             resolved.push(Arc::new(proj));
         }

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/tests.rs
-assertion_line: 41
+assertion_line: 42
 expression: conf
 ---
 Config {
@@ -181,6 +181,7 @@ Config {
         split: false,
         frontend_only: false,
         server_only: false,
+        target: None,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_bin_args_project2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/tests.rs
-assertion_line: 89
+assertion_line: 90
 expression: conf
 ---
 Config {
@@ -110,6 +110,7 @@ Config {
         split: false,
         frontend_only: false,
         server_only: false,
+        target: None,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_in_subdir_project2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/tests.rs
-assertion_line: 74
+assertion_line: 75
 expression: conf
 ---
 Config {
@@ -103,6 +103,7 @@ Config {
         split: false,
         frontend_only: false,
         server_only: false,
+        target: None,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project1.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/tests.rs
-assertion_line: 50
+assertion_line: 51
 expression: conf
 ---
 Config {
@@ -103,6 +103,7 @@ Config {
         split: false,
         frontend_only: false,
         server_only: false,
+        target: None,
     },
     watch: true,
     ..

--- a/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__workspace_project2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/tests.rs
-assertion_line: 59
+assertion_line: 60
 expression: conf
 ---
 Config {
@@ -105,6 +105,7 @@ Config {
         split: false,
         frontend_only: false,
         server_only: false,
+        target: None,
     },
     watch: true,
     ..

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -18,6 +18,7 @@ fn opts(project: Option<&str>) -> crate::config::Opts {
         frontend_only: false,
         server_only: false,
         clear: false,
+        target: None,
     }
 }
 


### PR DESCRIPTION
I realize after making this that I could've made a config file for cargo-leptos to read and label the target in variable 
```bash
bin-target-triple = "x86_64-unknown-linux-gnu"
``` 
but its nicer for end users as cli flag for testing or extra options