### PR TITLE
Add frontend Cargo target directory override

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ lib-profile-dev = "my-debug-profile"
 # Optional. Defaults to false prior to 0.2.3, unconditionally enabled (with the setting becoming deprecated) since 0.2.3 and #216
 separate-front-target-dir = true
 
+# Cargo target directory to use for frontend WASM builds. Relative paths are
+# resolved from the workspace root. Use CARGO_TARGET_DIR to share Cargo's normal
+# target directory, or CARGO_TARGET_DIR/front to spell out the default behavior.
+#
+# Optional. Defaults to CARGO_TARGET_DIR/front.
+front-target-dir = "CARGO_TARGET_DIR/front"
+
 # Pass additional parameters to the cargo process compiling to WASM
 #
 # Optional. No default

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -5,10 +5,69 @@ use crate::{
     logger::GRAY,
     service::site::{SiteFile, SourcedSiteFile},
 };
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::Metadata;
 
-use super::{project::ProjectDefinition, Profile, ProjectConfig};
+use super::{
+    project::{ProjectDefinition, CARGO_BUILD_TARGET_DIR_MARKER, CARGO_TARGET_DIR_MARKER},
+    Profile, ProjectConfig,
+};
+
+struct FrontTargetPaths {
+    rel: Utf8PathBuf,
+    abs: Utf8PathBuf,
+}
+
+impl FrontTargetPaths {
+    fn new(
+        target_directory: &Utf8Path,
+        workspace_root: &Utf8Path,
+        front_target_dir: Option<&Utf8Path>,
+    ) -> Self {
+        let abs = match front_target_dir {
+            Some(front_target_dir) => resolve_configured_front_target_dir(
+                target_directory,
+                workspace_root,
+                front_target_dir,
+            ),
+            None => target_directory.join("front"),
+        };
+        let rel = pathdiff::diff_utf8_paths(&abs, workspace_root).unwrap_or_else(|| abs.clone());
+        Self { rel, abs }
+    }
+}
+
+fn resolve_configured_front_target_dir(
+    target_directory: &Utf8Path,
+    workspace_root: &Utf8Path,
+    front_target_dir: &Utf8Path,
+) -> Utf8PathBuf {
+    if front_target_dir.as_str() == CARGO_TARGET_DIR_MARKER
+        || front_target_dir.as_str() == CARGO_BUILD_TARGET_DIR_MARKER
+    {
+        return target_directory.to_path_buf();
+    }
+
+    if front_target_dir.starts_with(CARGO_TARGET_DIR_MARKER) {
+        return front_target_dir
+            .unbase(Utf8Path::new(CARGO_TARGET_DIR_MARKER))
+            .map(|suffix| target_directory.join(suffix))
+            .unwrap_or_else(|_| target_directory.to_path_buf());
+    }
+
+    if front_target_dir.starts_with(CARGO_BUILD_TARGET_DIR_MARKER) {
+        return front_target_dir
+            .unbase(Utf8Path::new(CARGO_BUILD_TARGET_DIR_MARKER))
+            .map(|suffix| target_directory.join(suffix))
+            .unwrap_or_else(|_| target_directory.to_path_buf());
+    }
+
+    if front_target_dir.is_absolute() {
+        front_target_dir.to_path_buf()
+    } else {
+        workspace_root.join(front_target_dir)
+    }
+}
 
 pub struct LibPackage {
     pub name: String,
@@ -72,11 +131,15 @@ impl LibPackage {
             &config.lib_profile_release,
             &config.lib_profile_dev,
         );
+        let front_target_paths = FrontTargetPaths::new(
+            &metadata.target_directory,
+            &metadata.workspace_root,
+            config.front_target_dir.as_deref(),
+        );
 
         let wasm_file = {
-            let source = metadata
-                .rel_target_dir()
-                .join("front")
+            let source = front_target_paths
+                .rel
                 .join("wasm32-unknown-unknown")
                 .join(profile.to_string())
                 .join(target_lib.name.clone())
@@ -102,7 +165,7 @@ impl LibPackage {
             src_deps.push(rel_dir.join("src"));
         }
 
-        let front_target_path = metadata.target_directory.join("front");
+        let front_target_path = front_target_paths.abs;
         let cargo_args = cli
             .lib_cargo_args
             .clone()
@@ -146,5 +209,49 @@ impl std::fmt::Debug for LibPackage {
             )
             .field("profile", &self.profile)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn front_target_paths_use_dedicated_front_dir_by_default() {
+        let paths = FrontTargetPaths::new(
+            Utf8Path::new("/workspace/target"),
+            Utf8Path::new("/workspace"),
+            None,
+        );
+
+        assert_eq!(paths.rel, Utf8PathBuf::from("target/front"));
+        assert_eq!(paths.abs, Utf8PathBuf::from("/workspace/target/front"));
+    }
+
+    #[test]
+    fn front_target_paths_use_cargo_target_dir_marker() {
+        let paths = FrontTargetPaths::new(
+            Utf8Path::new("/workspace/target"),
+            Utf8Path::new("/workspace"),
+            Some(Utf8Path::new(CARGO_TARGET_DIR_MARKER)),
+        );
+
+        assert_eq!(paths.rel, Utf8PathBuf::from("target"));
+        assert_eq!(paths.abs, Utf8PathBuf::from("/workspace/target"));
+    }
+
+    #[test]
+    fn front_target_paths_resolve_workspace_relative_override() {
+        let paths = FrontTargetPaths::new(
+            Utf8Path::new("/workspace/target"),
+            Utf8Path::new("/workspace"),
+            Some(Utf8Path::new("custom/front-target")),
+        );
+
+        assert_eq!(paths.rel, Utf8PathBuf::from("custom/front-target"));
+        assert_eq!(
+            paths.abs,
+            Utf8PathBuf::from("/workspace/custom/front-target")
+        );
     }
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -19,9 +19,9 @@ use super::{
 };
 
 /// If the site root path starts with this marker, the marker should be replaced with the Cargo target directory
-const CARGO_TARGET_DIR_MARKER: &str = "CARGO_TARGET_DIR";
+pub(super) const CARGO_TARGET_DIR_MARKER: &str = "CARGO_TARGET_DIR";
 /// If the site root path starts with this marker, the marker should be replaced with the Cargo target directory
-const CARGO_BUILD_TARGET_DIR_MARKER: &str = "CARGO_BUILD_TARGET_DIR";
+pub(super) const CARGO_BUILD_TARGET_DIR_MARKER: &str = "CARGO_BUILD_TARGET_DIR";
 
 pub struct Project {
     /// absolute path to the working dir
@@ -348,6 +348,12 @@ pub struct ProjectConfig {
     pub config_dir: Utf8PathBuf,
     #[serde(skip)]
     pub tmp_dir: Utf8PathBuf,
+
+    /// The Cargo target directory to use when building the WASM frontend.
+    ///
+    /// Defaults to `CARGO_TARGET_DIR/front`, preserving the default dedicated
+    /// frontend target root.
+    pub front_target_dir: Option<Utf8PathBuf>,
 
     /// Deprecated. Keeping this here to warn users to remove it in case they have it in their config.
     #[deprecated = "This option is deprecated since cargo-leptos 0.2.3 (when it became unconditionally enabled). You may remove it from your config."]


### PR DESCRIPTION
Changes:
- Adds a `front-target-dir` metadata option for selecting the Cargo target directory used by frontend WASM builds.
- Resolves relative `front-target-dir` values from the workspace root and supports existing Cargo target directory markers.
- Uses the selected frontend target directory for both the Cargo `--target-dir` argument and hydrate WASM artifact lookup.
- Keeps the unset-option default at `<resolved Cargo target dir>/front` and documents the override.
- Adds unit coverage for default, marker-based, and workspace-relative frontend target directory resolution.

Why:
- This lets workflows opt into placing and reading WASM artifacts from the resolved Cargo target root when the dedicated frontend subdirectory does not match their build-cache layout.