### PR TITLE
chore: bump wasm_split_cli_support to 0.2.2 (retry failed split-chunk loads)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6281,12 +6281,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.248.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -6303,16 +6303,16 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_cli_support"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9ffc56e7385a8f85baae9bd923a10c2992edf2e74295a51024660ffaa27b42"
+checksum = "cc4cc38a709a5e1e1853988cba1f47495e8a154748b4c0537ee48ddd16297d53"
 dependencies = [
  "eyre",
  "lazy_static",
  "regex",
  "tracing",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -6329,9 +6329,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.17.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ignore = "0.4.25"
 walkdir = "2.5"
 regex = "1.12.3"
 clap_complete = "4.5.66"
-wasm_split_cli_support = "0.2.1"
+wasm_split_cli_support = "0.2.2"
 clearscreen = "4.0.5"
 tokio-process-tools = "0.11.0"
 


### PR DESCRIPTION
## What

Bumps `wasm_split_cli_support` `0.2.1` → `0.2.2` (Cargo.toml floor + lockfile).

## Why

0.2.1 generates a `__wasm_split.js` whose loader memoizes **rejected** load promises: a single transient network failure while fetching a split chunk (flaky connection, brief offline, server blip) permanently disables that chunk for the session — every later attempt to use the lazy-loaded code re-throws the cached rejection, and only a full page reload recovers. In a `--split` Leptos app this bricks lazy routes after one bad fetch.

0.2.2 memoizes successes only, so the next invocation after a failure retries the fetch ([WorldSEnder/wasm-split-prototype#36](https://github.com/WorldSEnder/wasm-split-prototype/pull/36), released 2026-06-28). This is the loader-side half of the recovery story for leptos-rs/leptos#4785 (surfacing chunk-load failures to `ErrorBoundary`), but it stands on its own: it turns a permanent brick into a plain retry regardless of how the Rust side handles the error.

The lockfile bump is the part that reaches users: `Cargo.toml`'s caret req already permits 0.2.2, but `cargo install cargo-leptos --locked` (the documented install) pins 0.2.1 until the lockfile moves.

## Compatibility

- `cargo check` / `cargo build` pass; the fixed loader template is confirmed embedded in the built binary.
- 0.2.2 also adds an optional link-time canary. Verified it degrades gracefully: the canary import is only emitted when the app's wasm was built with `wasm_split_helpers` ≥ 0.2.2 in debug; wasm built against older helpers carries no feature subsection and splits exactly as before, so this is a drop-in for existing apps.
- Transitive updates limited to what 0.2.2 requires: `wasm-encoder`/`wasmparser` 0.248 → 0.252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5Eb5TeDybfYmnuHeHPnhF