### PR TITLE
fix: detect host musl libc at runtime instead of compile time

### DIFF
--- a/src/ext/util.rs
+++ b/src/ext/util.rs
@@ -24,8 +24,38 @@ pub fn os_arch() -> Result<(&'static str, &'static str)> {
     Ok((target_os, target_arch))
 }
 
+/// Whether the *host* uses linux and musl libc. Best-effort detection at runtime, but
+/// falls back to compile time if it fails.
 pub fn is_linux_musl_env() -> bool {
-    cfg!(target_os = "linux") && cfg!(target_env = "musl")
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::sync::OnceLock;
+
+        static IS_MUSL: OnceLock<bool> = OnceLock::new();
+        *IS_MUSL.get_or_init(|| detect_host_libc_is_musl().unwrap_or(cfg!(target_env = "musl")))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn detect_host_libc_is_musl() -> Option<bool> {
+    use regex::Regex;
+    use std::process::Command;
+    use std::sync::LazyLock;
+
+    static LIBC_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)(musl)|glibc|gnu libc|gnu c library").unwrap());
+
+    let detect = |stream: &[u8]| {
+        let text = String::from_utf8_lossy(stream);
+        LIBC_RE.captures(&text).map(|caps| caps.get(1).is_some()) // 'musl' capture group
+    };
+
+    let output = Command::new("ldd").arg("--version").output().ok()?;
+    detect(&output.stdout).or_else(|| detect(&output.stderr))
 }
 
 pub trait StrAdditions {


### PR DESCRIPTION
## Problem

`is_linux_musl_env()` used `cfg!(target_env = "musl")`, which reflects how *cargo-leptos itself* was compiled, not the host it runs on. A statically linked musl build reports musl on any Linux host, so on glibc systems it downloads musl-linked tool binaries that then fail to dynamically link.

Concretely, this breaks CI. `taiki-e/install-action` installs the musl build of cargo-leptos on Ubuntu runners; that binary runs fine (it's static), but `is_linux_musl_env()` returns `true`, so `cargo leptos build` fetches `tailwindcss-linux-x64-musl`, whose ELF interpreter `/lib/ld-musl-x86_64.so.1` doesn't exist on glibc Ubuntu. The build fails with an opaque:

```
Error:
   0: No such file or directory (os error 2)
Location: src/ext/sync.rs:83
```

## Fix

Detect the host libc at runtime via `ldd --version` (glibc prints to stdout, musl to stderr), cache the result, and fall back to the compile-time value when detection is inconclusive (e.g. `ldd` unavailable).

I did not test it, but the fallback provides the same functionality as before.
